### PR TITLE
Load hiding zone configuration from URL parameter

### DIFF
--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -10,6 +10,7 @@ import {
     mapGeoLocation,
     polyGeoJSON,
     questions,
+    disabledStations,
     save,
     triggerLocalRefresh,
     hidingZone,
@@ -136,6 +137,11 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                     );
                     questions.set([]);
                 }
+
+                if (geojson.disabledStations !== null && geojson.disabledStations.constructor === Array) {
+                    disabledStations.set(geojson.disabledStations);
+                }
+
                 toast.success("Hiding zone loaded successfully", { autoClose: 2000 });
             }   
         } catch(e) {

--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -56,27 +56,33 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
 
     const $hidingZone = useStore(hidingZone);
 
-    hidingZone.listen(s => {
-        let _params = new URL(window.location.toString()).searchParams;
-        let _current = _params.get(hidingZoneUrlParam);
+    hidingZone.listen((s) => {
+        const _params = new URL(window.location.toString()).searchParams;
+        const _current = _params.get(hidingZoneUrlParam);
 
-        let b64 = btoa(JSON.stringify(s));
+        const b64 = btoa(JSON.stringify(s));
 
-        if (_current === b64) { return }
+        if (_current === b64) {
+            return;
+        }
 
-        const params = new URLSearchParams({[hidingZoneUrlParam]: b64});
-        window.history.pushState({}, "", `${window.location.pathname}?${params.toString()}`);
+        const params = new URLSearchParams({ [hidingZoneUrlParam]: b64 });
+        window.history.pushState(
+            {},
+            "",
+            `${window.location.pathname}?${params.toString()}`,
+        );
     });
 
     // Listen for history state changes to enable use of back-button to undo changes to zone
     useEffect(() => {
         const handler = () => {
-            let params = new URL(window.location.toString()).searchParams;
-            let hidingZone = params.get(hidingZoneUrlParam);
+            const params = new URL(window.location.toString()).searchParams;
+            const hidingZone = params.get(hidingZoneUrlParam);
             if (hidingZone !== null) {
                 try {
-                    loadHidingZone(atob(hidingZone));   
-                } catch(e) {
+                    loadHidingZone(atob(hidingZone));
+                } catch (e) {
                     toast.error(`Invalid hiding zone settings: ${e}`);
                 }
             }
@@ -87,7 +93,7 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
         window.addEventListener("popstate", handler);
         return () => {
             window.removeEventListener("popstate", handler);
-        }
+        };
     }, []);
 
     const loadHidingZone = (hidingZone) => {
@@ -96,59 +102,43 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
 
             if (
                 geojson.properties &&
-                geojson.properties
-                    .isHidingZone ===
-                    true
+                geojson.properties.isHidingZone === true
             ) {
-                mapGeoLocation.set(
-                    geojson,
-                );
+                mapGeoLocation.set(geojson);
                 mapGeoJSON.set(null);
                 polyGeoJSON.set(null);
                 questions.set(
-                    questionsSchema.parse(
-                        geojson
-                            .properties
-                            .questions ??
-                            [],
-                    ),
+                    questionsSchema.parse(geojson.properties.questions ?? []),
                 );
             } else {
                 if (geojson.questions) {
-                    questions.set(
-                        questionsSchema.parse(
-                            geojson.questions,
-                        ),
-                    );
+                    questions.set(questionsSchema.parse(geojson.questions));
                     delete geojson.questions;
 
-                    mapGeoJSON.set(
-                        geojson,
-                    );
-                    polyGeoJSON.set(
-                        geojson,
-                    );
+                    mapGeoJSON.set(geojson);
+                    polyGeoJSON.set(geojson);
                 } else {
-                    mapGeoJSON.set(
-                        geojson,
-                    );
-                    polyGeoJSON.set(
-                        geojson,
-                    );
+                    mapGeoJSON.set(geojson);
+                    polyGeoJSON.set(geojson);
                     questions.set([]);
                 }
             }
 
-            if (geojson.disabledStations !== null && geojson.disabledStations.constructor === Array) {
+            if (
+                geojson.disabledStations !== null &&
+                geojson.disabledStations.constructor === Array
+            ) {
                 disabledStations.set(geojson.disabledStations);
             }
 
             if (geojson.hidingRadius !== null) {
-                hidingRadius.set(geojson.hidingRadius)
+                hidingRadius.set(geojson.hidingRadius);
             }
 
-            toast.success("Hiding zone loaded successfully", { autoClose: 2000 });
-        } catch(e) {
+            toast.success("Hiding zone loaded successfully", {
+                autoClose: 2000,
+            });
+        } catch (e) {
             toast.error(`Invalid hiding zone settings: ${e}`);
         }
     };
@@ -279,7 +269,9 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                                             return toast.error(
                                                 "Clipboard not supported",
                                             );
-                                        navigator.clipboard.writeText(JSON.stringify($hidingZone));
+                                        navigator.clipboard.writeText(
+                                            JSON.stringify($hidingZone),
+                                        );
                                         toast.success(
                                             "Hiding zone copied successfully",
                                             {
@@ -296,7 +288,9 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                                             return toast.error(
                                                 "Clipboard not supported",
                                             );
-                                        navigator.clipboard.readText().then(loadHidingZone);
+                                        navigator.clipboard
+                                            .readText()
+                                            .then(loadHidingZone);
                                     }}
                                 >
                                     Paste Hiding Zone

--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -41,7 +41,7 @@ import {
 import { questionsSchema } from "@/lib/schema";
 import { UnitSelect } from "./UnitSelect";
 
-const hidingZoneUrlParam = "hz";
+const HIDING_ZONE_URL_PARAM = "hz";
 
 export const OptionDrawers = ({ className }: { className?: string }) => {
     useStore(triggerLocalRefresh);
@@ -51,34 +51,35 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
     const $hiderMode = useStore(hiderMode);
     const $hidingRadius = useStore(hidingRadius);
     const $autoSave = useStore(autoSave);
+    const $hidingZone = useStore(hidingZone);
     const [isInstructionsOpen, setInstructionsOpen] = useState(false);
     const [isOptionsOpen, setOptionsOpen] = useState(false);
 
-    const $hidingZone = useStore(hidingZone);
-
-    hidingZone.listen((s) => {
+    useEffect(() => {
         const _params = new URL(window.location.toString()).searchParams;
-        const _current = _params.get(hidingZoneUrlParam);
+        const _current = _params.get(HIDING_ZONE_URL_PARAM);
 
-        const b64 = btoa(JSON.stringify(s));
+        const b64 = btoa(JSON.stringify($hidingZone));
 
         if (_current === b64) {
             return;
         }
 
-        const params = new URLSearchParams({ [hidingZoneUrlParam]: b64 });
+        const params = new URLSearchParams({
+            [HIDING_ZONE_URL_PARAM]: b64,
+        });
         window.history.pushState(
             {},
             "",
             `${window.location.pathname}?${params.toString()}`,
         );
-    });
+    }, [$hidingZone]);
 
     // Listen for history state changes to enable use of back-button to undo changes to zone
     useEffect(() => {
         const handler = () => {
             const params = new URL(window.location.toString()).searchParams;
-            const hidingZone = params.get(hidingZoneUrlParam);
+            const hidingZone = params.get(HIDING_ZONE_URL_PARAM);
             if (hidingZone !== null) {
                 try {
                     loadHidingZone(atob(hidingZone));
@@ -96,7 +97,7 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
         };
     }, []);
 
-    const loadHidingZone = (hidingZone) => {
+    const loadHidingZone = (hidingZone: typeof $hidingZone) => {
         try {
             const geojson = JSON.parse(hidingZone);
 

--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -53,6 +53,8 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
     const [isInstructionsOpen, setInstructionsOpen] = useState(false);
     const [isOptionsOpen, setOptionsOpen] = useState(false);
 
+    const $hidingZone = useStore(hidingZone);
+
     hidingZone.listen(s => {
         let _params = new URL(window.location.toString()).searchParams;
         let _current = _params.get(hidingZoneUrlParam);
@@ -267,7 +269,7 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                                             return toast.error(
                                                 "Clipboard not supported",
                                             );
-                                        navigator.clipboard.writeText(JSON.stringify(hidingZone.get()));
+                                        navigator.clipboard.writeText(JSON.stringify($hidingZone));
                                         toast.success(
                                             "Hiding zone copied successfully",
                                             {

--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -137,13 +137,13 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                     );
                     questions.set([]);
                 }
+            }
 
-                if (geojson.disabledStations !== null && geojson.disabledStations.constructor === Array) {
-                    disabledStations.set(geojson.disabledStations);
-                }
+            if (geojson.disabledStations !== null && geojson.disabledStations.constructor === Array) {
+                disabledStations.set(geojson.disabledStations);
+            }
 
-                toast.success("Hiding zone loaded successfully", { autoClose: 2000 });
-            }   
+            toast.success("Hiding zone loaded successfully", { autoClose: 2000 });
         } catch(e) {
             toast.error(`Invalid hiding zone settings: ${e}`);
         }

--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -143,6 +143,10 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                 disabledStations.set(geojson.disabledStations);
             }
 
+            if (geojson.hidingRadius !== null) {
+                hidingRadius.set(geojson.hidingRadius)
+            }
+
             toast.success("Hiding zone loaded successfully", { autoClose: 2000 });
         } catch(e) {
             toast.error(`Invalid hiding zone settings: ${e}`);

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -131,21 +131,24 @@ export const save = () => {
 };
 
 // Exported hiding zone that can be loaded from clipboard or URL
-export const hidingZone = computed([questions, polyGeoJSON, mapGeoLocation, disabledStations, hidingRadius], (q, geo, loc, disabledStations, radius) => {
-    if (geo !== null) {
-        return {
-            ...geo,
-            questions: q,
-            disabledStations: disabledStations,
-            hidingRadius: radius,
+export const hidingZone = computed(
+    [questions, polyGeoJSON, mapGeoLocation, disabledStations, hidingRadius],
+    (q, geo, loc, disabledStations, radius) => {
+        if (geo !== null) {
+            return {
+                ...geo,
+                questions: q,
+                disabledStations: disabledStations,
+                hidingRadius: radius,
+            };
+        } else {
+            return {
+                ...loc,
+                isHidingZone: true,
+                questions: q,
+                disabledStations: disabledStations,
+                hidingRadius: radius,
+            };
         }
-    } else {
-        return {
-            ...loc,
-            isHidingZone: true,
-            questions: q,
-            disabledStations: disabledStations,
-            hidingRadius: radius,
-        }    
-    }
-})
+    },
+);

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,4 +1,4 @@
-import { atom } from "nanostores";
+import { atom, computed } from "nanostores";
 import { persistentAtom } from "@nanostores/persistent";
 import { type OpenStreetMap } from "../maps/api";
 import type { Map } from "leaflet";
@@ -129,3 +129,19 @@ export const save = () => {
         hiderMode.set({ ...$hiderMode });
     }
 };
+
+// Exported settings that can be loaded from clipboard or URL
+export const settings = computed([questions, polyGeoJSON, mapGeoLocation], (q, geo, loc) => {
+    if (geo !== null) {
+        return {
+            ...geo,
+            questions: q
+        }
+    } else {
+        return {
+            ...loc,
+            isHidingZone: true,
+            questions: q          
+        }    
+    }
+})

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -130,8 +130,8 @@ export const save = () => {
     }
 };
 
-// Exported settings that can be loaded from clipboard or URL
-export const settings = computed([questions, polyGeoJSON, mapGeoLocation], (q, geo, loc) => {
+// Exported hiding zone that can be loaded from clipboard or URL
+export const hidingZone = computed([questions, polyGeoJSON, mapGeoLocation], (q, geo, loc) => {
     if (geo !== null) {
         return {
             ...geo,

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -131,12 +131,13 @@ export const save = () => {
 };
 
 // Exported hiding zone that can be loaded from clipboard or URL
-export const hidingZone = computed([questions, polyGeoJSON, mapGeoLocation, disabledStations], (q, geo, loc, disabledStations) => {
+export const hidingZone = computed([questions, polyGeoJSON, mapGeoLocation, disabledStations, hidingRadius], (q, geo, loc, disabledStations, radius) => {
     if (geo !== null) {
         return {
             ...geo,
             questions: q,
             disabledStations: disabledStations,
+            hidingRadius: radius,
         }
     } else {
         return {
@@ -144,6 +145,7 @@ export const hidingZone = computed([questions, polyGeoJSON, mapGeoLocation, disa
             isHidingZone: true,
             questions: q,
             disabledStations: disabledStations,
+            hidingRadius: radius,
         }    
     }
 })

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -131,17 +131,19 @@ export const save = () => {
 };
 
 // Exported hiding zone that can be loaded from clipboard or URL
-export const hidingZone = computed([questions, polyGeoJSON, mapGeoLocation], (q, geo, loc) => {
+export const hidingZone = computed([questions, polyGeoJSON, mapGeoLocation, disabledStations], (q, geo, loc, disabledStations) => {
     if (geo !== null) {
         return {
             ...geo,
-            questions: q
+            questions: q,
+            disabledStations: disabledStations,
         }
     } else {
         return {
             ...loc,
             isHidingZone: true,
-            questions: q          
+            questions: q,
+            disabledStations: disabledStations,
         }    
     }
 })


### PR DESCRIPTION
I wanted a more user-friendly way to share the hiding zone with other players. This is a small change to export the hiding zone configuration to Base64-encoded JSON and set a URL parameter (`hz`) whenever the underlying configuration updates. The clipboard feature continues to use the old JSON format.

The only additional change I made is including the disabled stations and radius in the shared hiding zone configuration. This makes it easier for all players to agree on what are valid hiding zones within the search area.