### PR TITLE
Fix regression that overwrites URL hiding zone param with default configuration

### DIFF
--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -55,26 +55,6 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
     const [isInstructionsOpen, setInstructionsOpen] = useState(false);
     const [isOptionsOpen, setOptionsOpen] = useState(false);
 
-    useEffect(() => {
-        const _params = new URL(window.location.toString()).searchParams;
-        const _current = _params.get(HIDING_ZONE_URL_PARAM);
-
-        const b64 = btoa(JSON.stringify($hidingZone));
-
-        if (_current === b64) {
-            return;
-        }
-
-        const params = new URLSearchParams({
-            [HIDING_ZONE_URL_PARAM]: b64,
-        });
-        window.history.pushState(
-            {},
-            "",
-            `${window.location.pathname}?${params.toString()}`,
-        );
-    }, [$hidingZone]);
-
     // Listen for history state changes to enable use of back-button to undo changes to zone
     useEffect(() => {
         const handler = () => {
@@ -96,6 +76,27 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
             window.removeEventListener("popstate", handler);
         };
     }, []);
+
+    // Set URL state whenever hiding zone changes
+    useEffect(() => {
+        const _params = new URL(window.location.toString()).searchParams;
+        const _current = _params.get(HIDING_ZONE_URL_PARAM);
+        const b64 = btoa(JSON.stringify($hidingZone));
+
+        if (_current === b64) {
+            return;
+        }
+
+        const params = new URLSearchParams({
+            [HIDING_ZONE_URL_PARAM]: b64,
+        });
+        window.history.pushState(
+            {},
+            "",
+            `${window.location.pathname}?${params.toString()}`,
+        );
+    }, [$hidingZone]);
+
 
     const loadHidingZone = (hidingZone: typeof $hidingZone) => {
         try {


### PR DESCRIPTION
This pull request simply swaps the order of the useEffect function calls. Tested in Chrome and Firefox in private browsing mode to confirm the new configuration is loaded from the URL as intended. Otherwise whatever configuration is already saved in local storage (or the default) will override the URL param before it is read.