### PR TITLE
fix `unionize` return type

### DIFF
--- a/src/components/ZoneSidebar.tsx
+++ b/src/components/ZoneSidebar.tsx
@@ -196,7 +196,7 @@ export const ZoneSidebar = () => {
                     return circle;
                 })
                 .filter((circle) => {
-                    return !turf.booleanWithin(circle, unionized!);
+                    return !turf.booleanWithin(circle, unionized);
                 });
 
             for (const question of questions.get()) {
@@ -800,7 +800,7 @@ async function selectionProcess(
                 ...$questionFinishedMapData.features,
                 turf.mask(station),
             ]),
-        )!,
+        ),
     ]);
 
     for (const question of questions.get()) {
@@ -907,14 +907,14 @@ async function selectionProcess(
                             ...mapData.features,
                             turf.mask(correctPolygon),
                         ]),
-                    )!;
+                    );
                 } else {
                     mapData = unionize(
                         turf.featureCollection([
                             ...mapData.features,
                             correctPolygon,
                         ]),
-                    )!;
+                    );
                 }
             } else {
                 const circles = nearestPoints.map((x) =>
@@ -930,14 +930,14 @@ async function selectionProcess(
                             ...mapData.features,
                             holedMask(turf.featureCollection(circles)),
                         ]),
-                    )!;
+                    );
                 } else {
                     mapData = unionize(
                         turf.featureCollection([
                             ...mapData.features,
                             ...circles,
                         ]),
-                    )!;
+                    );
                 }
             }
         }
@@ -973,11 +973,11 @@ async function selectionProcess(
                         ...mapData.features,
                         holedMask(turf.featureCollection(circles)),
                     ]),
-                )!;
+                );
             } else {
                 mapData = unionize(
                     turf.featureCollection([...mapData.features, ...circles]),
-                )!;
+                );
             }
         }
         if (
@@ -1018,11 +1018,11 @@ async function selectionProcess(
                         ...mapData.features,
                         holedMask(turf.featureCollection(circles)),
                     ]),
-                )!;
+                );
             } else {
                 mapData = unionize(
                     turf.featureCollection([...mapData.features, ...circles]),
-                )!;
+                );
             }
         }
 

--- a/src/maps/geo-utils.ts
+++ b/src/maps/geo-utils.ts
@@ -2,13 +2,10 @@ import * as turf from "@turf/turf";
 import type { FeatureCollection, Polygon, MultiPolygon } from "geojson";
 
 export const unionize = (input: FeatureCollection<Polygon | MultiPolygon>) => {
-    if (input.features.length > 1) {
-        return turf.union(input);
-    } else if (input.features.length === 1) {
-        return input.features[0];
-    } else {
-        throw new Error("No features");
-    }
+    if (input.features.length === 1) return input.features[0];
+    const union = turf.union(input);
+    if (union) return union;
+    throw new Error("No features");
 };
 
 export const holedMask = (input: any) => {

--- a/src/maps/measuring.ts
+++ b/src/maps/measuring.ts
@@ -309,11 +309,11 @@ export const adjustPerMeasuring = async (
 
     if (question.hiderCloser) {
         return turf.intersect(
-            turf.featureCollection([unionize(mapData)!, buffer]),
+            turf.featureCollection([unionize(mapData), buffer]),
         );
     } else {
         return turf.intersect(
-            turf.featureCollection([unionize(mapData)!, holedMask(buffer)!]),
+            turf.featureCollection([unionize(mapData), holedMask(buffer)!]),
         );
     }
 };

--- a/src/maps/radius.ts
+++ b/src/maps/radius.ts
@@ -21,7 +21,7 @@ export const adjustPerRadius = (
         }
 
         return turf.intersect(
-            turf.featureCollection([unionize(mapData)!, circle]),
+            turf.featureCollection([unionize(mapData), circle]),
         );
     } else {
         if (!masked) {

--- a/src/maps/tentacles.ts
+++ b/src/maps/tentacles.ts
@@ -45,7 +45,7 @@ export const adjustPerTentacle = async (
     );
 
     return turf.intersect(
-        turf.featureCollection([unionize(mapData)!, correctPolygon, circle]),
+        turf.featureCollection([unionize(mapData), correctPolygon, circle]),
     );
 };
 

--- a/src/maps/thermometer.ts
+++ b/src/maps/thermometer.ts
@@ -21,11 +21,11 @@ export const adjustPerThermometer = (
 
     if (question.warmer) {
         return turf.intersect(
-            turf.featureCollection([unionize(mapData)!, voronoi.features[1]]),
+            turf.featureCollection([unionize(mapData), voronoi.features[1]]),
         );
     } else {
         return turf.intersect(
-            turf.featureCollection([unionize(mapData)!, voronoi.features[0]]),
+            turf.featureCollection([unionize(mapData), voronoi.features[0]]),
         );
     }
 };


### PR DESCRIPTION
- [x] TS indicated that`unionize` might return `null`.
- [x] This was because `turf.unionize` returns `null`; however, that only happens if there are zero features.
- [x] Since `unionize` `throw`s if there are zero features, `unionize` cannot return `null`.
- [x] This PR fixes the return type of `unionize`, so that its return type does not need to be non-null asserted throughout the codebase.