### PR TITLE
remove an `any` from `tentacles.tsx`

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "eslint-plugin-react": "^7.37.4",
         "globals": "^16.0.0",
         "prettier": "3.5.0",
+        "type-fest": "^4.40.1",
         "typescript-eslint": "^8.24.0"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       prettier:
         specifier: 3.5.0
         version: 3.5.0
+      type-fest:
+        specifier: ^4.40.1
+        version: 4.40.1
       typescript-eslint:
         specifier: ^8.24.0
         version: 8.24.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3)
@@ -4701,8 +4704,8 @@ packages:
     resolution: {integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==}
     engines: {node: '>=10'}
 
-  type-fest@4.33.0:
-    resolution: {integrity: sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==}
+  type-fest@4.40.1:
+    resolution: {integrity: sha512-9YvLNnORDpI+vghLU/Nf+zSv0kL47KbVJ1o3sKgoTefl6i+zebxbiDQWoe/oWWqPhIgQdRZRT1KA9sCPL810SA==}
     engines: {node: '>=16'}
 
   typed-array-buffer@1.0.3:
@@ -8528,7 +8531,7 @@ snapshots:
       chalk: 5.4.1
       cli-boxes: 3.0.0
       string-width: 7.2.0
-      type-fest: 4.33.0
+      type-fest: 4.40.1
       widest-line: 5.0.0
       wrap-ansi: 9.0.0
 
@@ -11113,7 +11116,7 @@ snapshots:
 
   type-fest@0.16.0: {}
 
-  type-fest@4.33.0: {}
+  type-fest@4.40.1: {}
 
   typed-array-buffer@1.0.3:
     dependencies:

--- a/src/components/cards/tentacles.tsx
+++ b/src/components/cards/tentacles.tsx
@@ -30,6 +30,7 @@ import type {
 } from "@/lib/schema";
 import { UnitSelect } from "../UnitSelect";
 import * as turf from "@turf/turf";
+import type { KeysOfUnion, ValueOf } from "type-fest";
 
 export const TentacleQuestionComponent = ({
     data,
@@ -54,6 +55,21 @@ export const TentacleQuestionComponent = ({
             .map((q) => q.key)
             .indexOf(questionKey) + 1
     }`;
+
+    const tentacleGroups = {
+        "": { custom: "Custom Locations" },
+        "15 Miles (Typically)": {
+            theme_park: "Theme Parks",
+            zoo: "Zoos",
+            aquarium: "Aquariums",
+        },
+        "1 Mile (Typically)": {
+            museum: "Museums",
+            hospital: "Hospitals",
+            cinema: "Movie Theater",
+            library: "Library",
+        },
+    };
 
     return (
         <QuestionCard
@@ -88,7 +104,10 @@ export const TentacleQuestionComponent = ({
             <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
                 <Select
                     value={data.locationType}
-                    onValueChange={async (value) => {
+                    onValueChange={async (untypedValue) => {
+                        const value = untypedValue as KeysOfUnion<
+                            ValueOf<typeof tentacleGroups>
+                        >;
                         if (value === "custom") {
                             const priorLocations = await findTentacleLocations(
                                 data as TraditionalTentacleQuestion,
@@ -107,7 +126,7 @@ export const TentacleQuestionComponent = ({
                             data.location = false;
                         } else {
                             data.location = false;
-                            data.locationType = value as any;
+                            data.locationType = value;
                         }
                         questionModified();
                     }}
@@ -117,24 +136,23 @@ export const TentacleQuestionComponent = ({
                         <SelectValue placeholder="Location Type" />
                     </SelectTrigger>
                     <SelectContent>
-                        <SelectItem value="custom">Custom Locations</SelectItem>
-                        <SelectGroup>
-                            <SelectLabel>15 Miles (Typically)</SelectLabel>
-                            <SelectItem value="theme_park">
-                                Theme Parks
-                            </SelectItem>
-                            <SelectItem value="zoo">Zoos</SelectItem>
-                            <SelectItem value="aquarium">Aquariums</SelectItem>
-                        </SelectGroup>
-                        <SelectGroup>
-                            <SelectLabel>1 Mile (Typically)</SelectLabel>
-                            <SelectItem value="museum">Museums</SelectItem>
-                            <SelectItem value="hospital">Hospitals</SelectItem>
-                            <SelectItem value="cinema">
-                                Movie Theater
-                            </SelectItem>
-                            <SelectItem value="library">Library</SelectItem>
-                        </SelectGroup>
+                        {Object.entries(tentacleGroups).map(
+                            ([children, types]) => (
+                                <SelectGroup key={children}>
+                                    {children && (
+                                        <SelectLabel {...{ children }} />
+                                    )}
+                                    {Object.entries(types).map(
+                                        ([value, children]) => (
+                                            <SelectItem
+                                                key={value}
+                                                {...{ value, children }}
+                                            />
+                                        ),
+                                    )}
+                                </SelectGroup>
+                            ),
+                        )}
                     </SelectContent>
                 </Select>
             </SidebarMenuItem>


### PR DESCRIPTION
- [x] `@radix-ui/react-select` => `<Select>` => `onValueChange` provides `value: string` (coming from `<SelectItem value />`), but `data.locationType` needs it to be a specific string.
- [x] Create a data structure that is used both to make the `<SelectGroup>`s and to assert on `value`. This way, we will get a TS error if the options ever fall out of sync with `data.locationType`.
- [x] Move `type-fest` — which was already installed — up to the top level of `node_modules`, so that we can use it