### PR TITLE
typed selects

### DIFF
--- a/src/components/LatLngPicker.tsx
+++ b/src/components/LatLngPicker.tsx
@@ -6,13 +6,7 @@ import {
 } from "./ui/sidebar-l";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "./ui/select";
+import { Select } from "./ui/select";
 import { isLoading } from "@/lib/context";
 
 export const LatitudeLongitude = ({
@@ -54,6 +48,11 @@ export const LatitudeLongitude = ({
                     disabled={disabled}
                 />
                 <Select
+                    trigger={{
+                        placeholder: "Direction",
+                        className: "max-w-[55px]",
+                    }}
+                    options={{ north: "N", south: "S" }}
                     onValueChange={(value) =>
                         onChange(
                             value === "north"
@@ -64,15 +63,7 @@ export const LatitudeLongitude = ({
                     }
                     value={latitude > 0 ? "north" : "south"}
                     disabled={disabled}
-                >
-                    <SelectTrigger className="max-w-[55px]">
-                        <SelectValue placeholder="Direction"></SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                        <SelectItem value="north">N</SelectItem>
-                        <SelectItem value="south">S</SelectItem>
-                    </SelectContent>
-                </Select>
+                />
             </SidebarMenuItem>
             <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
                 <Label className="leading-5">{lngLabel}</Label>
@@ -93,6 +84,11 @@ export const LatitudeLongitude = ({
                     disabled={disabled}
                 />
                 <Select
+                    trigger={{
+                        placeholder: "Direction",
+                        className: "max-w-[55px]",
+                    }}
+                    options={{ east: "E", west: "W" }}
                     onValueChange={(value) =>
                         onChange(
                             null,
@@ -103,15 +99,7 @@ export const LatitudeLongitude = ({
                     }
                     value={longitude > 0 ? "east" : "west"}
                     disabled={disabled}
-                >
-                    <SelectTrigger className="max-w-[55px]">
-                        <SelectValue placeholder="Direction"></SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                        <SelectItem value="east">E</SelectItem>
-                        <SelectItem value="west">W</SelectItem>
-                    </SelectContent>
-                </Select>
+                />
             </SidebarMenuItem>
             <SidebarMenuItem>
                 <SidebarMenuButton

--- a/src/components/UnitSelect.tsx
+++ b/src/components/UnitSelect.tsx
@@ -1,11 +1,5 @@
 import type { Units } from "@/lib/schema";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "./ui/select";
+import { Select } from "./ui/select";
 
 export const UnitSelect = ({
     unit,
@@ -17,15 +11,16 @@ export const UnitSelect = ({
     disabled?: boolean;
 }) => {
     return (
-        <Select disabled={disabled} value={unit} onValueChange={onChange}>
-            <SelectTrigger>
-                <SelectValue placeholder="Unit" />
-            </SelectTrigger>
-            <SelectContent>
-                <SelectItem value="miles">Miles</SelectItem>
-                <SelectItem value="kilometers">Kilometers</SelectItem>
-                <SelectItem value="meters">Meters</SelectItem>
-            </SelectContent>
-        </Select>
+        <Select
+            trigger="Unit"
+            options={{
+                miles: "Miles",
+                kilometers: "Kilometers",
+                meters: "Meters",
+            }}
+            disabled={disabled}
+            value={unit}
+            onValueChange={onChange}
+        />
     );
 };

--- a/src/components/ZoneSidebar.tsx
+++ b/src/components/ZoneSidebar.tsx
@@ -49,13 +49,7 @@ import { toast } from "react-toastify";
 import _ from "lodash";
 import { MultiSelect } from "./ui/multi-select";
 import { Input } from "./ui/input";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select";
+import { Select } from "@/components/ui/select";
 import { geoSpatialVoronoi } from "@/maps/voronoi";
 import { ScrollToTop } from "./ui/scroll-to-top";
 
@@ -466,16 +460,12 @@ export const ZoneSidebar = () => {
                                         }}
                                         disabled={$isLoading}
                                     />
-                                    <Select value="miles" disabled>
-                                        <SelectTrigger>
-                                            <SelectValue placeholder="Unit" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="miles">
-                                                Miles
-                                            </SelectItem>
-                                        </SelectContent>
-                                    </Select>
+                                    <Select
+                                        trigger="Unit"
+                                        value="miles"
+                                        options={{ miles: "Miles" }}
+                                        disabled
+                                    />
                                 </div>
                             </SidebarMenuItem>
                             {$displayHidingZones && stations.length > 0 && (

--- a/src/components/cards/measuring.tsx
+++ b/src/components/cards/measuring.tsx
@@ -1,6 +1,6 @@
 import { LatitudeLongitude } from "../LatLngPicker";
 import { useStore } from "@nanostores/react";
-import { cn } from "../../lib/utils";
+import { cn, mapToObj } from "../../lib/utils";
 import {
     displayHidingZones,
     drawingQuestionKey,
@@ -12,18 +12,10 @@ import {
 } from "../../lib/context";
 import { iconColors, prettifyLocation } from "../../maps/api";
 import { MENU_ITEM_CLASSNAME, SidebarMenuItem } from "../ui/sidebar-l";
-import {
-    Select,
-    SelectContent,
-    SelectGroup,
-    SelectItem,
-    SelectLabel,
-    SelectTrigger,
-    SelectValue,
-} from "../ui/select";
+import { Select } from "../ui/select";
 import { Checkbox } from "../ui/checkbox";
 import { QuestionCard } from "./base";
-import type { MeasuringQuestion, TentacleLocations } from "@/lib/schema";
+import type { MeasuringQuestion } from "@/lib/schema";
 import { determineMeasuringBoundary } from "@/maps/measuring";
 
 export const MeasuringQuestionComponent = ({
@@ -118,6 +110,61 @@ export const MeasuringQuestionComponent = ({
         >
             <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
                 <Select
+                    trigger="Measuring Type"
+                    options={{
+                        coastline: "Coastline Question",
+                        airport: "Commercial Airport In Zone Question",
+                        city: "Major City (1,000,000+ people) Question",
+                        "highspeed-measure-shinkansen":
+                            "High-Speed Rail Question",
+                        ...mapToObj(
+                            [
+                                "aquarium",
+                                "zoo",
+                                "theme_park",
+                                "museum",
+                                "hospital",
+                                "cinema",
+                                "library",
+                                "golf_course",
+                                "consulate",
+                                "park",
+                            ] as const,
+                            (location) => [
+                                `${location}-full`,
+                                `${prettifyLocation(location)} Question (Small+Medium Games)`,
+                            ],
+                        ),
+                        "custom-measure": "Custom Measuring Question",
+                    }}
+                    groups={{
+                        "Hiding Zone Mode": {
+                            disabled: !$displayHidingZones,
+                            options: {
+                                mcdonalds: "McDonald's Question",
+                                seven11: "7-Eleven Question",
+                                "rail-measure": "Train Station Question",
+                                ...mapToObj(
+                                    [
+                                        "aquarium",
+                                        "zoo",
+                                        "theme_park",
+                                        "museum",
+                                        "hospital",
+                                        "cinema",
+                                        "library",
+                                        "golf_course",
+                                        "consulate",
+                                        "park",
+                                    ] as const,
+                                    (location) => [
+                                        location,
+                                        `${prettifyLocation(location)} Question (Large Game)`,
+                                    ],
+                                ),
+                            },
+                        },
+                    }}
                     value={data.type}
                     onValueChange={async (value) => {
                         if (value === "custom-measure") {
@@ -135,98 +182,11 @@ export const MeasuringQuestionComponent = ({
                                 ? boundary
                                 : [];
                         }
-                        data.type = value as any;
+                        data.type = value;
                         questionModified();
                     }}
                     disabled={!data.drag || $isLoading}
-                >
-                    <SelectTrigger>
-                        <SelectValue placeholder="Measuring Type" />
-                    </SelectTrigger>
-                    <SelectContent>
-                        <SelectItem value="coastline">
-                            Coastline Question
-                        </SelectItem>
-                        <SelectItem value="airport">
-                            Commercial Airport In Zone Question
-                        </SelectItem>
-                        <SelectItem value="city">
-                            Major City (1,000,000+ people) Question
-                        </SelectItem>
-                        <SelectItem value="highspeed-measure-shinkansen">
-                            High-Speed Rail Question
-                        </SelectItem>
-                        {(
-                            [
-                                "aquarium",
-                                "zoo",
-                                "theme_park",
-                                "museum",
-                                "hospital",
-                                "cinema",
-                                "library",
-                                "golf_course",
-                                "consulate",
-                                "park",
-                            ] as TentacleLocations[]
-                        ).map((location) => (
-                            <SelectItem
-                                value={location + "-full"}
-                                key={location + "-full"}
-                            >
-                                {prettifyLocation(location)} Question
-                                (Small+Medium Games)
-                            </SelectItem>
-                        ))}
-                        <SelectItem value="custom-measure">
-                            Custom Measuring Question
-                        </SelectItem>
-                        <SelectGroup>
-                            <SelectLabel>Hiding Zone Mode</SelectLabel>
-                            <SelectItem
-                                value="mcdonalds"
-                                disabled={!$displayHidingZones}
-                            >
-                                McDonald&apos;s Question
-                            </SelectItem>
-                            <SelectItem
-                                value="seven11"
-                                disabled={!$displayHidingZones}
-                            >
-                                7-Eleven Question
-                            </SelectItem>
-                            <SelectItem
-                                value="rail-measure"
-                                disabled={!$displayHidingZones}
-                            >
-                                Train Station Question
-                            </SelectItem>
-                            {(
-                                [
-                                    "aquarium",
-                                    "zoo",
-                                    "theme_park",
-                                    "museum",
-                                    "hospital",
-                                    "cinema",
-                                    "library",
-                                    "golf_course",
-                                    "consulate",
-                                    "park",
-                                ] as TentacleLocations[]
-                            ).map((location) => (
-                                <SelectItem
-                                    value={location}
-                                    key={location}
-                                    disabled={!$displayHidingZones}
-                                >
-                                    {prettifyLocation(location)} Question (Large
-                                    Game)
-                                </SelectItem>
-                            ))}
-                        </SelectGroup>
-                    </SelectContent>
-                </Select>
+                />
             </SidebarMenuItem>
             {questionSpecific}
             <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>

--- a/src/components/cards/tentacles.tsx
+++ b/src/components/cards/tentacles.tsx
@@ -1,27 +1,19 @@
 import { Suspense, use } from "react";
 import { LatitudeLongitude } from "../LatLngPicker";
 import { useStore } from "@nanostores/react";
-import { cn } from "../../lib/utils";
+import { cn, mapToObj } from "../../lib/utils";
 import {
     drawingQuestionKey,
     hiderMode,
+    isLoading,
     questionModified,
     questions,
     triggerLocalRefresh,
-    isLoading,
 } from "../../lib/context";
 import { findTentacleLocations, iconColors } from "../../maps/api";
 import { MENU_ITEM_CLASSNAME, SidebarMenuItem } from "../ui/sidebar-l";
 import { Input } from "../ui/input";
-import {
-    Select,
-    SelectContent,
-    SelectGroup,
-    SelectItem,
-    SelectLabel,
-    SelectTrigger,
-    SelectValue,
-} from "../ui/select";
+import { Select } from "../ui/select";
 import { Checkbox } from "../ui/checkbox";
 import { QuestionCard } from "./base";
 import type {
@@ -87,6 +79,21 @@ export const TentacleQuestionComponent = ({
             </SidebarMenuItem>
             <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
                 <Select
+                    trigger="Location Type"
+                    options={{ custom: "Custom Locations" }}
+                    groups={{
+                        "15 Miles (Typically)": {
+                            theme_park: "Theme Parks",
+                            zoo: "Zoos",
+                            aquarium: "Aquariums",
+                        },
+                        "1 Mile (Typically)": {
+                            museum: "Museums",
+                            hospital: "Hospitals",
+                            cinema: "Movie Theater",
+                            library: "Library",
+                        },
+                    }}
                     value={data.locationType}
                     onValueChange={async (value) => {
                         if (value === "custom") {
@@ -107,36 +114,12 @@ export const TentacleQuestionComponent = ({
                             data.location = false;
                         } else {
                             data.location = false;
-                            data.locationType = value as any;
+                            data.locationType = value;
                         }
                         questionModified();
                     }}
                     disabled={!data.drag || $isLoading}
-                >
-                    <SelectTrigger>
-                        <SelectValue placeholder="Location Type" />
-                    </SelectTrigger>
-                    <SelectContent>
-                        <SelectItem value="custom">Custom Locations</SelectItem>
-                        <SelectGroup>
-                            <SelectLabel>15 Miles (Typically)</SelectLabel>
-                            <SelectItem value="theme_park">
-                                Theme Parks
-                            </SelectItem>
-                            <SelectItem value="zoo">Zoos</SelectItem>
-                            <SelectItem value="aquarium">Aquariums</SelectItem>
-                        </SelectGroup>
-                        <SelectGroup>
-                            <SelectLabel>1 Mile (Typically)</SelectLabel>
-                            <SelectItem value="museum">Museums</SelectItem>
-                            <SelectItem value="hospital">Hospitals</SelectItem>
-                            <SelectItem value="cinema">
-                                Movie Theater
-                            </SelectItem>
-                            <SelectItem value="library">Library</SelectItem>
-                        </SelectGroup>
-                    </SelectContent>
-                </Select>
+                />
             </SidebarMenuItem>
             {data.locationType === "custom" && data.drag && (
                 <p className="px-2 mb-1 text-center text-orange-500">
@@ -243,6 +226,14 @@ const TentacleLocationSelector = ({
 
     return (
         <Select
+            trigger="Location"
+            options={{
+                false: "Not Within",
+                ...mapToObj(locations.features, (feature: any) => [
+                    feature.properties.name,
+                    feature.properties.name,
+                ]),
+            }}
             value={data.location ? data.location.properties.name : "false"}
             onValueChange={(value) => {
                 if (value === "false") {
@@ -256,21 +247,6 @@ const TentacleLocationSelector = ({
                 questionModified();
             }}
             disabled={!!$hiderMode || disabled}
-        >
-            <SelectTrigger>
-                <SelectValue placeholder="Location" />
-            </SelectTrigger>
-            <SelectContent>
-                <SelectItem value="false">Not Within</SelectItem>
-                {locations.features.map((feature: any) => (
-                    <SelectItem
-                        key={feature.properties.name}
-                        value={feature.properties.name}
-                    >
-                        {feature.properties.name}
-                    </SelectItem>
-                ))}
-            </SelectContent>
-        </Select>
+        />
     );
 };

--- a/src/components/cards/tentacles.tsx
+++ b/src/components/cards/tentacles.tsx
@@ -17,7 +17,7 @@ import { Select } from "../ui/select";
 import { Checkbox } from "../ui/checkbox";
 import { QuestionCard } from "./base";
 import {
-    determineUnionedStrings,
+    determineUnionizedStrings,
     NO_GROUP,
     tentacleQuestionSchema,
     type TentacleQuestion,
@@ -87,7 +87,7 @@ export const TentacleQuestionComponent = ({
                         tentacleQuestionSchema.options
                             .filter((x) => x.description === NO_GROUP)
                             .flatMap((x) =>
-                                determineUnionedStrings(x.shape.locationType),
+                                determineUnionizedStrings(x.shape.locationType),
                             )
                             .map((x) => [(x._def as any).value, x.description]),
                     )}
@@ -97,7 +97,7 @@ export const TentacleQuestionComponent = ({
                             .map((x) => [
                                 x.description,
                                 Object.fromEntries(
-                                    determineUnionedStrings(
+                                    determineUnionizedStrings(
                                         x.shape.locationType,
                                     ).map((x) => [
                                         (x._def as any).value,

--- a/src/components/cards/tentacles.tsx
+++ b/src/components/cards/tentacles.tsx
@@ -16,9 +16,12 @@ import { Input } from "../ui/input";
 import { Select } from "../ui/select";
 import { Checkbox } from "../ui/checkbox";
 import { QuestionCard } from "./base";
-import type {
-    TentacleQuestion,
-    TraditionalTentacleQuestion,
+import {
+    determineUnionedStrings,
+    NO_GROUP,
+    tentacleQuestionSchema,
+    type TentacleQuestion,
+    type TraditionalTentacleQuestion,
 } from "@/lib/schema";
 import { UnitSelect } from "../UnitSelect";
 import * as turf from "@turf/turf";
@@ -80,20 +83,29 @@ export const TentacleQuestionComponent = ({
             <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
                 <Select
                     trigger="Location Type"
-                    options={{ custom: "Custom Locations" }}
-                    groups={{
-                        "15 Miles (Typically)": {
-                            theme_park: "Theme Parks",
-                            zoo: "Zoos",
-                            aquarium: "Aquariums",
-                        },
-                        "1 Mile (Typically)": {
-                            museum: "Museums",
-                            hospital: "Hospitals",
-                            cinema: "Movie Theater",
-                            library: "Library",
-                        },
-                    }}
+                    options={Object.fromEntries(
+                        tentacleQuestionSchema.options
+                            .filter((x) => x.description === NO_GROUP)
+                            .flatMap((x) =>
+                                determineUnionedStrings(x.shape.locationType),
+                            )
+                            .map((x) => [(x._def as any).value, x.description]),
+                    )}
+                    groups={Object.fromEntries(
+                        tentacleQuestionSchema.options
+                            .filter((x) => x.description !== NO_GROUP)
+                            .map((x) => [
+                                x.description,
+                                Object.fromEntries(
+                                    determineUnionedStrings(
+                                        x.shape.locationType,
+                                    ).map((x) => [
+                                        (x._def as any).value,
+                                        x.description,
+                                    ]),
+                                ),
+                            ]),
+                    )}
                     value={data.locationType}
                     onValueChange={async (value) => {
                         if (value === "custom") {

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -4,7 +4,70 @@ import { Check, ChevronDown, ChevronUp } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
-const Select = SelectPrimitive.Root;
+type Options<T extends string> = Partial<Record<T, string>>;
+const Select = <T extends string>({
+    trigger,
+    options,
+    groups,
+    ...rest
+}: {
+    disabled?: boolean;
+    trigger: string | Record<"className" | "placeholder", string>;
+    options?: Options<T>;
+    groups?: Record<
+        string,
+        { disabled: boolean; options: Options<T> } | Options<T>
+    >;
+    onValueChange?: (value: T) => void;
+    value: T;
+}) => {
+    const { placeholder, className } =
+        typeof trigger == "string" ? { placeholder: trigger } : trigger;
+    const mapObj = <T,>(
+        obj: Partial<Record<string, T>>,
+        fn: (key: string, value: T) => React.ReactNode,
+    ) => Object.entries(obj).map(([k, v]) => fn(k, v!));
+    const Options = ({
+        options,
+        ...rest
+    }: {
+        options: Options<T>;
+        disabled?: boolean;
+    }) =>
+        mapObj(options, (value, children) => (
+            <SelectItem key={value} {...{ ...rest, value, children }} />
+        ));
+    return (
+        <SelectPrimitive.Root {...rest}>
+            <SelectTrigger {...{ className }}>
+                <SelectValue {...{ placeholder }} />
+            </SelectTrigger>
+            <SelectContent>
+                {options && <Options {...{ options }} />}
+                {groups &&
+                    mapObj(groups, (children, optionsOrConfig) => {
+                        return (
+                            <SelectGroup key={children}>
+                                <SelectLabel {...{ children }} />
+                                <Options
+                                    {...("options" in optionsOrConfig &&
+                                    typeof optionsOrConfig.options == "object"
+                                        ? optionsOrConfig
+                                        : {
+                                              options:
+                                                  optionsOrConfig as Record<
+                                                      T,
+                                                      string
+                                                  >,
+                                          })}
+                                />
+                            </SelectGroup>
+                        );
+                    })}
+            </SelectContent>
+        </SelectPrimitive.Root>
+    );
+};
 
 const SelectGroup = SelectPrimitive.Group;
 

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -284,57 +284,81 @@ const baseMeasuringQuestionSchema = ordinaryBaseQuestionSchema.extend({
 const ordinaryMeasuringQuestionSchema = baseMeasuringQuestionSchema.extend({
     type: z
         .union([
-            z.literal("coastline"),
-            z.literal("airport"),
-            z.literal("city"),
-            z.literal("highspeed-measure-shinkansen"),
-            z.literal("aquarium-full"),
-            z.literal("zoo-full"),
-            z.literal("theme_park-full"),
-            z.literal("museum-full"),
-            z.literal("hospital-full"),
-            z.literal("cinema-full"),
-            z.literal("library-full"),
-            z.literal("golf_course-full"),
-            z.literal("consulate-full"),
-            z.literal("park-full"),
+            z.literal("coastline").describe("Coastline Question"),
+            z
+                .literal("airport")
+                .describe("Commercial Airport In Zone Question"),
+            z
+                .literal("city")
+                .describe("Major City (1,000,000+ people) Question"),
+            z
+                .literal("highspeed-measure-shinkansen")
+                .describe("High-Speed Rail Question"),
+            z
+                .literal("aquarium-full")
+                .describe("Aquarium Question (Small+Medium Games)"),
+            z.literal("zoo-full").describe("Zoo Question (Small+Medium Games)"),
+            z
+                .literal("theme_park-full")
+                .describe("Theme Park Question (Small+Medium Games)"),
+            z
+                .literal("museum-full")
+                .describe("Museum Question (Small+Medium Games)"),
+            z
+                .literal("hospital-full")
+                .describe("Hospital Question (Small+Medium Games)"),
+            z
+                .literal("cinema-full")
+                .describe("Cinema Question (Small+Medium Games)"),
+            z
+                .literal("library-full")
+                .describe("Library Question (Small+Medium Games)"),
+            z
+                .literal("golf_course-full")
+                .describe("Golf Course Question (Small+Medium Games)"),
+            z
+                .literal("consulate-full")
+                .describe("Foreign Consulate Question (Small+Medium Games)"),
+            z
+                .literal("park-full")
+                .describe("Park Question (Small+Medium Games)"),
         ])
         .default("coastline"),
 });
 
 const hidingZoneMeasuringQuestionsSchema = baseMeasuringQuestionSchema.extend({
     type: z.union([
-        z.literal("mcdonalds"),
-        z.literal("seven11"),
-        z.literal("rail-measure"),
+        z.literal("mcdonalds").describe("McDonald's Question"),
+        z.literal("seven11").describe("7-Eleven Question"),
+        z.literal("rail-measure").describe("Train Station Question"),
     ]),
 });
 
 const homeGameMeasuringQuestionsSchema = baseMeasuringQuestionSchema.extend({
     type: z.union([
-        z.literal("aquarium"),
-        z.literal("zoo"),
-        z.literal("theme_park"),
-        z.literal("museum"),
-        z.literal("hospital"),
-        z.literal("cinema"),
-        z.literal("library"),
-        z.literal("golf_course"),
-        z.literal("consulate"),
-        z.literal("park"),
+        z.literal("aquarium").describe("Aquarium Question"),
+        z.literal("zoo").describe("Zoo Question"),
+        z.literal("theme_park").describe("Theme Park Question"),
+        z.literal("museum").describe("Museum Question"),
+        z.literal("hospital").describe("Hospital Question"),
+        z.literal("cinema").describe("Cinema Question"),
+        z.literal("library").describe("Library Question"),
+        z.literal("golf_course").describe("Golf Course Question"),
+        z.literal("consulate").describe("Foreign Consulate Question"),
+        z.literal("park").describe("Park Question"),
     ]),
 });
 
 const customMeasuringQuestionSchema = baseMeasuringQuestionSchema.extend({
-    type: z.literal("custom-measure"),
+    type: z.literal("custom-measure").describe("Custom Measuring Question"),
     geo: z.any(),
 });
 
-const measuringQuestionSchema = z.union([
-    ordinaryMeasuringQuestionSchema,
-    hidingZoneMeasuringQuestionsSchema,
-    homeGameMeasuringQuestionsSchema,
-    customMeasuringQuestionSchema,
+export const measuringQuestionSchema = z.union([
+    ordinaryMeasuringQuestionSchema.describe(NO_GROUP),
+    customMeasuringQuestionSchema.describe(NO_GROUP),
+    hidingZoneMeasuringQuestionsSchema.describe("Hiding Zone Mode"),
+    homeGameMeasuringQuestionsSchema.describe("Hiding Zone Mode"),
 ]);
 
 export const questionSchema = z.union([

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -3,17 +3,17 @@ import { z } from "zod";
 
 export const NO_GROUP = "NO_GROUP";
 
-export const determineUnionedStrings = (
+export const determineUnionizedStrings = (
     obj: z.ZodUnion<any> | z.ZodLiteral<any> | z.ZodDefault<any>,
 ): z.ZodLiteral<any>[] => {
     if (obj instanceof z.ZodUnion) {
         return obj.options.flatMap((option: any) =>
-            determineUnionedStrings(option),
+            determineUnionizedStrings(option),
         );
     } else if (obj instanceof z.ZodLiteral) {
         return [obj];
     } else if (obj instanceof z.ZodDefault) {
-        return determineUnionedStrings(obj._def.innerType);
+        return determineUnionizedStrings(obj._def.innerType);
     }
     return [];
 };
@@ -172,24 +172,49 @@ const baseMatchingQuestionSchema = ordinaryBaseQuestionSchema.extend({
 
 const ordinaryMatchingQuestionSchema = baseMatchingQuestionSchema.extend({
     type: z.union([
-        z.literal("airport"),
-        z.literal("major-city"),
-        z.literal("aquarium-full"),
-        z.literal("zoo-full"),
-        z.literal("theme_park-full"),
-        z.literal("museum-full"),
-        z.literal("hospital-full"),
-        z.literal("cinema-full"),
-        z.literal("library-full"),
-        z.literal("golf_course-full"),
-        z.literal("consulate-full"),
-        z.literal("park-full"),
+        z
+            .literal("airport")
+            .describe("Same Nearest Commercial Airport In Zone"),
+        z
+            .literal("major-city")
+            .describe("Closest Commercial Airport In Zone Question"),
+        z
+            .literal("aquarium-full")
+            .describe("Aquarium Question (Small+Medium Games)"),
+        z.literal("zoo-full").describe("Zoo Question (Small+Medium Games)"),
+        z
+            .literal("theme_park-full")
+            .describe("Theme Park Question (Small+Medium Games)"),
+        z
+            .literal("museum-full")
+            .describe("Museum Question (Small+Medium Games)"),
+        z
+            .literal("hospital-full")
+            .describe("Hospital Question (Small+Medium Games)"),
+        z
+            .literal("cinema-full")
+            .describe("Cinema Question (Small+Medium Games)"),
+        z
+            .literal("library-full")
+            .describe("Library Question (Small+Medium Games)"),
+        z
+            .literal("golf_course-full")
+            .describe("Golf Course Question (Small+Medium Games)"),
+        z
+            .literal("consulate-full")
+            .describe("Foreign Consulate Question (Small+Medium Games)"),
+        z.literal("park-full").describe("Park Question (Small+Medium Games)"),
     ]),
 });
 
 const zoneMatchingQuestionsSchema = baseMatchingQuestionSchema.extend({
     type: z
-        .union([z.literal("zone"), z.literal("letter-zone")])
+        .union([
+            z.literal("zone").describe("Zone Question"),
+            z
+                .literal("letter-zone")
+                .describe("Zone Starts With Same Letter Question"),
+        ])
         .default("zone"),
     cat: z
         .object({
@@ -209,38 +234,47 @@ const zoneMatchingQuestionsSchema = baseMatchingQuestionSchema.extend({
 
 const homeGameMatchingQuestionsSchema = baseMatchingQuestionSchema.extend({
     type: z.union([
-        z.literal("aquarium"),
-        z.literal("zoo"),
-        z.literal("theme_park"),
-        z.literal("museum"),
-        z.literal("hospital"),
-        z.literal("cinema"),
-        z.literal("library"),
-        z.literal("golf_course"),
-        z.literal("consulate"),
-        z.literal("park"),
+        z.literal("aquarium").describe("Aquarium Question"),
+        z.literal("zoo").describe("Zoo Question"),
+        z.literal("theme_park").describe("Theme Park Question"),
+        z.literal("museum").describe("Museum Question"),
+        z.literal("hospital").describe("Hospital Question"),
+        z.literal("cinema").describe("Cinema Question"),
+        z.literal("library").describe("Library Question"),
+        z.literal("golf_course").describe("Golf Course Question"),
+        z.literal("consulate").describe("Foreign Consulate Question"),
+        z.literal("park").describe("Park Question"),
     ]),
 });
 
 const hidingZoneMatchingQuestionsSchema = baseMatchingQuestionSchema.extend({
     type: z.union([
-        z.literal("same-first-letter-station"),
-        z.literal("same-length-station"),
-        z.literal("same-train-line"),
+        z
+            .literal("same-first-letter-station")
+            .describe("Station Starts With Same Letter Question"),
+        z
+            .literal("same-length-station")
+            .describe("Station Has Same Length Question"),
+        z
+            .literal("same-train-line")
+            .describe("Station On Same Train Line Question"),
     ]),
 });
 
 const customMatchingQuestionSchema = baseMatchingQuestionSchema.extend({
-    type: z.union([z.literal("custom-zone"), z.literal("custom-points")]),
+    type: z.union([
+        z.literal("custom-zone").describe("Custom Zone Question"),
+        z.literal("custom-points").describe("Custom Points Question"),
+    ]),
     geo: z.any(),
 });
 
-const matchingQuestionSchema = z.union([
-    zoneMatchingQuestionsSchema,
-    ordinaryMatchingQuestionSchema,
-    homeGameMatchingQuestionsSchema,
-    hidingZoneMatchingQuestionsSchema,
-    customMatchingQuestionSchema,
+export const matchingQuestionSchema = z.union([
+    zoneMatchingQuestionsSchema.describe(NO_GROUP),
+    ordinaryMatchingQuestionSchema.describe(NO_GROUP),
+    customMatchingQuestionSchema.describe(NO_GROUP),
+    hidingZoneMatchingQuestionsSchema.describe("Hiding Zone Mode"),
+    homeGameMatchingQuestionsSchema.describe("Hiding Zone Mode"),
 ]);
 
 const baseMeasuringQuestionSchema = ordinaryBaseQuestionSchema.extend({

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -67,17 +67,25 @@ const radiusQuestionSchema = ordinaryBaseQuestionSchema.extend({
     within: z.boolean().default(true),
 });
 
-const tentacleLocationsSchema = z.union([
+const tentacleLocationsFifteen = z.union([
     z.literal("aquarium"),
     z.literal("zoo"),
     z.literal("theme_park"),
+]);
+
+const tentacleLocationsOne = z.union([
     z.literal("museum"),
     z.literal("hospital"),
     z.literal("cinema"),
     z.literal("library"),
+]);
+
+const apiLocationSchema = z.union([
     z.literal("golf_course"),
     z.literal("consulate"),
     z.literal("park"),
+    tentacleLocationsFifteen,
+    tentacleLocationsOne,
 ]);
 
 const baseTentacleQuestionSchema = ordinaryBaseQuestionSchema.extend({
@@ -101,7 +109,9 @@ const baseTentacleQuestionSchema = ordinaryBaseQuestionSchema.extend({
         .default(false),
 });
 const tentacleQuestionSpecificSchema = baseTentacleQuestionSchema.extend({
-    locationType: tentacleLocationsSchema.default("theme_park"),
+    locationType: z
+        .union([tentacleLocationsFifteen, tentacleLocationsOne])
+        .default("theme_park"),
     places: z.array(z.any()).optional(),
 });
 
@@ -135,9 +145,6 @@ const ordinaryMatchingQuestionSchema = baseMatchingQuestionSchema.extend({
     type: z.union([
         z.literal("airport"),
         z.literal("major-city"),
-        z.literal("same-first-letter-station"),
-        z.literal("same-length-station"),
-        z.literal("same-train-line"),
         z.literal("aquarium-full"),
         z.literal("zoo-full"),
         z.literal("theme_park-full"),
@@ -186,6 +193,14 @@ const homeGameMatchingQuestionsSchema = baseMatchingQuestionSchema.extend({
     ]),
 });
 
+const hidingZoneMatchingQuestionsSchema = baseMatchingQuestionSchema.extend({
+    type: z.union([
+        z.literal("same-first-letter-station"),
+        z.literal("same-length-station"),
+        z.literal("same-train-line"),
+    ]),
+});
+
 const customMatchingQuestionSchema = baseMatchingQuestionSchema.extend({
     type: z.union([z.literal("custom-zone"), z.literal("custom-points")]),
     geo: z.any(),
@@ -195,6 +210,7 @@ const matchingQuestionSchema = z.union([
     zoneMatchingQuestionsSchema,
     ordinaryMatchingQuestionSchema,
     homeGameMatchingQuestionsSchema,
+    hidingZoneMatchingQuestionsSchema,
     customMatchingQuestionSchema,
 ]);
 
@@ -208,9 +224,6 @@ const ordinaryMeasuringQuestionSchema = baseMeasuringQuestionSchema.extend({
             z.literal("coastline"),
             z.literal("airport"),
             z.literal("city"),
-            z.literal("mcdonalds"),
-            z.literal("seven11"),
-            z.literal("rail-measure"),
             z.literal("highspeed-measure-shinkansen"),
             z.literal("aquarium-full"),
             z.literal("zoo-full"),
@@ -224,6 +237,14 @@ const ordinaryMeasuringQuestionSchema = baseMeasuringQuestionSchema.extend({
             z.literal("park-full"),
         ])
         .default("coastline"),
+});
+
+const hidingZoneMeasuringQuestionsSchema = baseMeasuringQuestionSchema.extend({
+    type: z.union([
+        z.literal("mcdonalds"),
+        z.literal("seven11"),
+        z.literal("rail-measure"),
+    ]),
 });
 
 const homeGameMeasuringQuestionsSchema = baseMeasuringQuestionSchema.extend({
@@ -248,6 +269,7 @@ const customMeasuringQuestionSchema = baseMeasuringQuestionSchema.extend({
 
 const measuringQuestionSchema = z.union([
     ordinaryMeasuringQuestionSchema,
+    hidingZoneMeasuringQuestionsSchema,
     homeGameMeasuringQuestionsSchema,
     customMeasuringQuestionSchema,
 ]);
@@ -286,7 +308,7 @@ export type Units = z.infer<typeof unitsSchema>;
 export type RadiusQuestion = z.infer<typeof radiusQuestionSchema>;
 export type ThermometerQuestion = z.infer<typeof thermometerQuestionSchema>;
 export type TentacleQuestion = z.infer<typeof tentacleQuestionSchema>;
-export type TentacleLocations = z.infer<typeof tentacleLocationsSchema>;
+export type APILocations = z.infer<typeof apiLocationSchema>;
 export type MatchingQuestion = z.infer<typeof matchingQuestionSchema>;
 export type HomeGameMatchingQuestions = z.infer<
     typeof homeGameMatchingQuestionsSchema

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,8 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
 }
+
+export const mapToObj = <T, K extends string, V>(
+    arr: T[],
+    fn: (item: T) => [K, V],
+) => Object.fromEntries(arr.map(fn));

--- a/src/maps/api.ts
+++ b/src/maps/api.ts
@@ -8,7 +8,7 @@ import { toast } from "react-toastify";
 import type {
     HomeGameMatchingQuestions,
     HomeGameMeasuringQuestions,
-    TentacleLocations,
+    APILocations,
 } from "@/lib/schema";
 
 export interface OpenStreetMap {
@@ -98,7 +98,7 @@ export const determineGeoJSON = async (
 };
 
 export const locationFirstTag: {
-    [key in TentacleLocations]:
+    [key in APILocations]:
         | "amenity"
         | "tourism"
         | "leisure"
@@ -490,7 +490,7 @@ export const clearCache = async (cacheType: CacheType = CacheType.CACHE) => {
     }
 };
 
-export const prettifyLocation = (location: TentacleLocations) => {
+export const prettifyLocation = (location: APILocations) => {
     switch (location) {
         case "aquarium":
             return "Aquarium";

--- a/src/maps/api.ts
+++ b/src/maps/api.ts
@@ -2,7 +2,10 @@ import type { LatLngTuple } from "leaflet";
 import osmtogeojson from "osmtogeojson";
 import * as turf from "@turf/turf";
 import { mapGeoLocation, polyGeoJSON } from "@/lib/context";
-import type { Question, TraditionalTentacleQuestion } from "@/lib/schema";
+import type {
+    EncompassingTentacleQuestionSchema,
+    Question,
+} from "@/lib/schema";
 import _ from "lodash";
 import { toast } from "react-toastify";
 import type {
@@ -98,11 +101,7 @@ export const determineGeoJSON = async (
 };
 
 export const locationFirstTag: {
-    [key in APILocations]:
-        | "amenity"
-        | "tourism"
-        | "leisure"
-        | "diplomatic";
+    [key in APILocations]: "amenity" | "tourism" | "leisure" | "diplomatic";
 } = {
     aquarium: "tourism",
     hospital: "amenity",
@@ -117,7 +116,7 @@ export const locationFirstTag: {
 };
 
 export const findTentacleLocations = async (
-    question: TraditionalTentacleQuestion,
+    question: EncompassingTentacleQuestionSchema,
     text: string = "Determining tentacle locations...",
 ) => {
     const query = `

--- a/src/maps/matching.ts
+++ b/src/maps/matching.ts
@@ -21,7 +21,7 @@ import { holedMask, unionize } from "./geo-utils";
 import type {
     HomeGameMatchingQuestions,
     MatchingQuestion,
-    TentacleLocations,
+    APILocations,
 } from "@/lib/schema";
 import type {
     Feature,
@@ -77,7 +77,7 @@ export const findMatchingPlaces = async (question: MatchingQuestion) => {
         case "park-full": {
             const location = question.type.split(
                 "-full",
-            )[0] as TentacleLocations;
+            )[0] as APILocations;
 
             const data = await findPlacesInZone(
                 `[${locationFirstTag[location]}=${location}]`,

--- a/src/maps/matching.ts
+++ b/src/maps/matching.ts
@@ -75,9 +75,7 @@ export const findMatchingPlaces = async (question: MatchingQuestion) => {
         case "golf_course-full":
         case "consulate-full":
         case "park-full": {
-            const location = question.type.split(
-                "-full",
-            )[0] as APILocations;
+            const location = question.type.split("-full")[0] as APILocations;
 
             const data = await findPlacesInZone(
                 `[${locationFirstTag[location]}=${location}]`,

--- a/src/maps/measuring.ts
+++ b/src/maps/measuring.ts
@@ -185,9 +185,7 @@ export const determineMeasuringBoundary = async (
         case "golf_course-full":
         case "consulate-full":
         case "park-full": {
-            const location = question.type.split(
-                "-full",
-            )[0] as APILocations;
+            const location = question.type.split("-full")[0] as APILocations;
 
             const data = await findPlacesInZone(
                 `[${locationFirstTag[location]}=${location}]`,

--- a/src/maps/measuring.ts
+++ b/src/maps/measuring.ts
@@ -27,7 +27,7 @@ import osmtogeojson from "osmtogeojson";
 import type {
     MeasuringQuestion,
     HomeGameMeasuringQuestions,
-    TentacleLocations,
+    APILocations,
 } from "@/lib/schema";
 import { toast } from "react-toastify";
 
@@ -187,7 +187,7 @@ export const determineMeasuringBoundary = async (
         case "park-full": {
             const location = question.type.split(
                 "-full",
-            )[0] as TentacleLocations;
+            )[0] as APILocations;
 
             const data = await findPlacesInZone(
                 `[${locationFirstTag[location]}=${location}]`,


### PR DESCRIPTION
- [x] `@radix-ui/react-select` => `<Select />` => `onValueChange` receives a `string` based on the `value` of the `<SelectItem />`, but several places throughout this app need it to be more accurately typed — they are currently using `as any`s.
- [x] This PR refactors select menus to use an all-in-one `<Select />` component that generates all parts of the select UI, and is completely typed.