### PR TITLE
fix hydration errors by moving some things to client-side rendering

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,7 +18,7 @@ import { OptionDrawers } from "@/components/OptionDrawers";
 <Layout className="bg-jetlag">
     <SidebarProviderL client:load>
         <SidebarProviderR client:load defaultOpen={false}>
-            <QuestionSidebar client:load />
+            <QuestionSidebar client:only />
             <main class="flex flex-col flex-grow group">
                 <div
                     class="flex justify-center"
@@ -38,7 +38,7 @@ import { OptionDrawers } from "@/components/OptionDrawers";
                         <div
                             class="flex flex-shrink max-w-fit z-[1030] absolute left-4 right-0 m-auto group-[.fullscreen]:hidden"
                         >
-                            <PlacePicker client:load className="m-4 overflow-hidden" />
+                            <PlacePicker client:only className="m-4 overflow-hidden" />
                         </div>
                         <div
                             class="bottom-5 right-2 mx-auto mb-2 w-fit absolute z-[1030] group-[.fullscreen]:hidden"


### PR DESCRIPTION
- [x] If you open the app with data saved in your `localStorage`, there are hydration errors where Astro complains about how some parts of the server-rendered HTML don't match the client-rendered HTML. This is because the client loads data from `localStorage`, whereas the server uses the default value.
- [x] This PR fixes that issue by marking components which use `persistentAtom` with `client:only`.