### PR TITLE
enforce using import aliases

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,9 @@
 import globals from "globals";
 import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
+import pluginImportAlias from "eslint-plugin-import-alias";
 import pluginReact from "eslint-plugin-react";
+import tsconfig from "./tsconfig.json" with { type: "json" };
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -11,12 +13,25 @@ export default [
     ...tseslint.configs.recommended,
     pluginReact.configs.flat.recommended,
     {
+        plugins: { "import-alias": pluginImportAlias },
         settings: {
             react: {
                 version: "19",
             },
         },
         rules: {
+            "import-alias/import-alias": [
+                "error",
+                {
+                    relativeDepth: 1,
+                    aliases: Object.entries(tsconfig.compilerOptions.paths).map(
+                        ([to, [from]]) => ({
+                            alias: to.replace(/\*$/, ""),
+                            matcher: from.replace(/^\.\//, "^"),
+                        }),
+                    ),
+                },
+            ],
             "react/react-in-jsx-scope": "off",
             "@typescript-eslint/no-explicit-any": "off", // Would be great to remove all `any` types...
         },

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "@types/react-dom": "19.0.3",
         "eslint": "^9.19.0",
         "eslint-config-prettier": "^10.0.1",
+        "eslint-plugin-import-alias": "^1.2.0",
         "eslint-plugin-react": "^7.37.4",
         "globals": "^16.0.0",
         "prettier": "3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.0.1
         version: 10.0.1(eslint@9.19.0(jiti@1.21.7))
+      eslint-plugin-import-alias:
+        specifier: ^1.2.0
+        version: 1.2.0
       eslint-plugin-react:
         specifier: ^7.37.4
         version: 7.37.4(eslint@9.19.0(jiti@1.21.7))
@@ -1090,8 +1093,8 @@ packages:
     resolution: {integrity: sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/eslintrc@3.2.0':
-    resolution: {integrity: sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==}
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/js@9.19.0':
@@ -3369,6 +3372,9 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
+
+  eslint-plugin-import-alias@1.2.0:
+    resolution: {integrity: sha512-hxhpWtaXgBTeCUmQa6EzjKI8vnrk7uej9e+ln2etTMPFAM7Q8xNPdBywSGrWf2mSB018D66sR1ZfdThonXCplg==}
 
   eslint-plugin-react@7.37.4:
     resolution: {integrity: sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==}
@@ -6542,7 +6548,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.2.0':
+  '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
       debug: 4.4.0
@@ -9674,6 +9680,8 @@ snapshots:
     dependencies:
       eslint: 9.19.0(jiti@1.21.7)
 
+  eslint-plugin-import-alias@1.2.0: {}
+
   eslint-plugin-react@7.37.4(eslint@9.19.0(jiti@1.21.7)):
     dependencies:
       array-includes: 3.1.8
@@ -9711,7 +9719,7 @@ snapshots:
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.19.2
       '@eslint/core': 0.10.0
-      '@eslint/eslintrc': 3.2.0
+      '@eslint/eslintrc': 3.3.1
       '@eslint/js': 9.19.0
       '@eslint/plugin-kit': 0.2.5
       '@humanfs/node': 0.16.6

--- a/src/components/cards/base.tsx
+++ b/src/components/cards/base.tsx
@@ -1,8 +1,8 @@
 import { VscChromeClose, VscChevronDown } from "react-icons/vsc";
 import { useState } from "react";
 import { useStore } from "@nanostores/react";
-import { cn } from "../../lib/utils";
-import { questions } from "../../lib/context";
+import { cn } from "@/lib/utils";
+import { questions } from "@/lib/context";
 import {
     SidebarGroup,
     SidebarGroupContent,

--- a/src/components/cards/matching.tsx
+++ b/src/components/cards/matching.tsx
@@ -1,6 +1,6 @@
 import { LatitudeLongitude } from "../LatLngPicker";
 import { useStore } from "@nanostores/react";
-import { cn } from "../../lib/utils";
+import { cn } from "@/lib/utils";
 import {
     displayHidingZones,
     drawingQuestionKey,
@@ -9,9 +9,9 @@ import {
     questionModified,
     questions,
     triggerLocalRefresh,
-} from "../../lib/context";
-import { iconColors, prettifyLocation } from "../../maps/api";
-import type { MatchingQuestion, TentacleLocations } from "../../lib/schema";
+} from "@/lib/context";
+import { iconColors, prettifyLocation } from "@/maps/api";
+import type { MatchingQuestion, TentacleLocations } from "@/lib/schema";
 import { MENU_ITEM_CLASSNAME, SidebarMenuItem } from "../ui/sidebar-l";
 import {
     Select,

--- a/src/components/cards/measuring.tsx
+++ b/src/components/cards/measuring.tsx
@@ -1,6 +1,6 @@
 import { LatitudeLongitude } from "../LatLngPicker";
 import { useStore } from "@nanostores/react";
-import { cn } from "../../lib/utils";
+import { cn } from "@/lib/utils";
 import {
     displayHidingZones,
     drawingQuestionKey,
@@ -9,8 +9,8 @@ import {
     questions,
     triggerLocalRefresh,
     isLoading,
-} from "../../lib/context";
-import { iconColors, prettifyLocation } from "../../maps/api";
+} from "@/lib/context";
+import { iconColors, prettifyLocation } from "@/maps/api";
 import { MENU_ITEM_CLASSNAME, SidebarMenuItem } from "../ui/sidebar-l";
 import {
     Select,

--- a/src/components/cards/radius.tsx
+++ b/src/components/cards/radius.tsx
@@ -1,15 +1,15 @@
-import type { RadiusQuestion } from "../../lib/schema";
+import type { RadiusQuestion } from "@/lib/schema";
 import { LatitudeLongitude } from "../LatLngPicker";
 import { useStore } from "@nanostores/react";
-import { cn } from "../../lib/utils";
+import { cn } from "@/lib/utils";
 import {
     hiderMode,
     questionModified,
     questions,
     triggerLocalRefresh,
     isLoading,
-} from "../../lib/context";
-import { iconColors } from "../../maps/api";
+} from "@/lib/context";
+import { iconColors } from "@/maps/api";
 import { MENU_ITEM_CLASSNAME, SidebarMenuItem } from "../ui/sidebar-l";
 import { Input } from "../ui/input";
 import { Checkbox } from "../ui/checkbox";

--- a/src/components/cards/tentacles.tsx
+++ b/src/components/cards/tentacles.tsx
@@ -1,7 +1,7 @@
 import { Suspense, use } from "react";
 import { LatitudeLongitude } from "../LatLngPicker";
 import { useStore } from "@nanostores/react";
-import { cn } from "../../lib/utils";
+import { cn } from "@/lib/utils";
 import {
     drawingQuestionKey,
     hiderMode,
@@ -9,8 +9,8 @@ import {
     questions,
     triggerLocalRefresh,
     isLoading,
-} from "../../lib/context";
-import { findTentacleLocations, iconColors } from "../../maps/api";
+} from "@/lib/context";
+import { findTentacleLocations, iconColors } from "@/maps/api";
 import { MENU_ITEM_CLASSNAME, SidebarMenuItem } from "../ui/sidebar-l";
 import { Input } from "../ui/input";
 import {

--- a/src/components/cards/thermometer.tsx
+++ b/src/components/cards/thermometer.tsx
@@ -1,14 +1,14 @@
 import { LatitudeLongitude } from "../LatLngPicker";
 import { useStore } from "@nanostores/react";
-import { cn } from "../../lib/utils";
+import { cn } from "@/lib/utils";
 import {
     hiderMode,
     questionModified,
     questions,
     triggerLocalRefresh,
     isLoading,
-} from "../../lib/context";
-import { iconColors } from "../../maps/api";
+} from "@/lib/context";
+import { iconColors } from "@/maps/api";
 import { MENU_ITEM_CLASSNAME, SidebarMenuItem } from "../ui/sidebar-l";
 import { Checkbox } from "../ui/checkbox";
 import { Separator } from "../ui/separator";


### PR DESCRIPTION
The project has the `@` import alias configured, but it is used inconsistently throughout the codebase.

- [x] Add `eslint-plugin-import-alias` to manage import alias usage
- [x] Auto-generate the configuration for this plugin based on the existing alias config
- [x] Run the new autofixable rule on the codebase