### PR TITLE
Subway and Light Rail stations for Hiding Zones

### DIFF
--- a/src/components/ZoneSidebar.tsx
+++ b/src/components/ZoneSidebar.tsx
@@ -436,6 +436,14 @@ export const ZoneSidebar = () => {
                                             label: "Railway Stations Excluding Subways",
                                             value: "[railway=station][subway!=yes]",
                                         },
+                                        {
+                                            label: "Subway Stations",
+                                            value: "[railway=station][subway=yes]",
+                                        },
+                                        {
+                                            label: "Light Rail Stations",
+                                            value: "[railway=station][light_rail=yes]",
+                                        }
                                     ]}
                                     onValueChange={
                                         displayHidingZonesOptions.set


### PR DESCRIPTION
Adds Hiding Zone options for specifically Subway and Light Rail stations, excluding regional rail.