### PR TITLE
Create button to disable all currently listed stations.

### DIFF
--- a/src/components/ZoneSidebar.tsx
+++ b/src/components/ZoneSidebar.tsx
@@ -631,6 +631,23 @@ export const ZoneSidebar = () => {
                                     </SidebarMenuItem>
                                 )}
                             {$displayHidingZones && (
+                                <SidebarMenuItem
+                                    className="bg-popover hover:bg-accent relative flex cursor-pointer gap-2 select-none items-center rounded-sm px-2 py-2.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0"
+                                    onClick={() => {
+                                        disabledStations.set(
+                                            stations.map(
+                                                (x) =>
+                                                    x.properties.properties.id,
+                                            ),
+                                        );
+                                        removeHidingZones();
+                                    }}
+                                    disabled={$isLoading}
+                                >
+                                    Disable All
+                                </SidebarMenuItem>
+                            )}
+                            {$displayHidingZones && (
                                 <Command>
                                     <CommandInput
                                         placeholder="Search for a hiding zone..."


### PR DESCRIPTION
Button disables all listed stations and clears the displayed hiding zones (since all stations have been disabled).

![Screenshot 2025-05-04 161206](https://github.com/user-attachments/assets/b4637cd7-814e-4690-88a5-f0d1357f779e)
