### PR TITLE
fix: Compress hiding zone URL param

### DIFF
--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -32,7 +32,7 @@ import {
 } from "@/components/ui/drawer";
 import { Separator } from "./ui/separator";
 import { useStore } from "@nanostores/react";
-import { cn } from "@/lib/utils";
+import { cn, compress, decompress } from "@/lib/utils";
 import { useEffect, useState } from "react";
 import { Checkbox } from "./ui/checkbox";
 import { LatitudeLongitude } from "./LatLngPicker";
@@ -46,6 +46,7 @@ import { UnitSelect } from "./UnitSelect";
 import { Input } from "./ui/input";
 
 const HIDING_ZONE_URL_PARAM = "hz";
+const HIDING_ZONE_COMPRESSED_URL_PARAM = "hzc";
 
 export const OptionDrawers = ({ className }: { className?: string }) => {
     useStore(triggerLocalRefresh);
@@ -64,15 +65,32 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
 
     useEffect(() => {
         const params = new URL(window.location.toString()).searchParams;
-        const hidingZone = params.get(HIDING_ZONE_URL_PARAM);
-        if (hidingZone !== null) {
+        const hidingZoneOld = params.get(HIDING_ZONE_URL_PARAM);
+        const hidingZone = params.get(HIDING_ZONE_COMPRESSED_URL_PARAM);
+        if (hidingZoneOld !== null) {
+            // Legacy base64 encoding
             try {
-                loadHidingZone(atob(hidingZone));
+                loadHidingZone(atob(hidingZoneOld));
                 // Remove hiding zone parameter after initial load
                 window.history.replaceState({}, "", window.location.pathname);
             } catch (e) {
                 toast.error(`Invalid hiding zone settings: ${e}`);
             }
+        } else if (hidingZone !== null) {
+            // Modern compressed format
+            decompress(hidingZone).then((data) => {
+                try {
+                    loadHidingZone(data);
+                    // Remove hiding zone parameter after initial load
+                    window.history.replaceState(
+                        {},
+                        "",
+                        window.location.pathname,
+                    );
+                } catch (e) {
+                    toast.error(`Invalid hiding zone settings: ${e}`);
+                }
+            });
         }
     }, []);
 
@@ -138,9 +156,9 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
         >
             <Button
                 className="shadow-md"
-                onClick={() => {
-                    const b64 = btoa(JSON.stringify($hidingZone));
-                    const url = `${window.location.protocol}//${window.location.host}${window.location.pathname}?hz=${b64}`;
+                onClick={async () => {
+                    const b64 = await compress(JSON.stringify($hidingZone));
+                    const url = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${HIDING_ZONE_COMPRESSED_URL_PARAM}=${b64}`;
 
                     // Show platform native share sheet if possible
                     if (navigator.share) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,3 +9,47 @@ export const mapToObj = <T, K extends string, V>(
     arr: T[],
     fn: (item: T) => [K, V],
 ) => Object.fromEntries(arr.map(fn));
+
+export const compress = async (
+    str: string,
+    encoding = "deflate" as CompressionFormat,
+): Promise<string> => {
+    const byteArray = new TextEncoder().encode(str);
+    const cs = new CompressionStream(encoding);
+    const writer = cs.writable.getWriter();
+    writer.write(byteArray);
+    writer.close();
+    const arrayBuffer = await new Response(cs.readable).arrayBuffer();
+
+    const bytes = new Uint8Array(arrayBuffer);
+    let binary = "";
+    for (let i = 0; i < bytes.byteLength; i++) {
+        binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary)
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=/g, "");
+};
+
+export const decompress = async (
+    base64String: string,
+    encoding = "deflate" as CompressionFormat,
+): Promise<string> => {
+    const regularBase64 = base64String.replace(/-/g, "+").replace(/_/g, "/");
+    const paddedBase64 =
+        regularBase64 + "=".repeat((4 - (regularBase64.length % 4)) % 4);
+
+    const binaryString = atob(paddedBase64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+    }
+
+    const cs = new DecompressionStream(encoding);
+    const writer = cs.writable.getWriter();
+    writer.write(bytes);
+    writer.close();
+    const arrayBuffer = await new Response(cs.readable).arrayBuffer();
+    return new TextDecoder().decode(arrayBuffer);
+};


### PR DESCRIPTION
This compresses the hiding zone URL param using deflate instead of just b64-encoding it. The URL parameter is renamed to `?hzc`, so that old b64-encoded `?hz` URLs continue to work. In tests, an 8256 char long string increased to 11008 chars when b64-encoded, while decreasing to 1780 chars with deflate. The `CompressionStream` API that's being used here is part of Baseline 2023, so it should be widely available.

Closes #116