### PR TITLE
feat: Redesign Lat/Long picker and layout of question cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.1.2",
+        "@radix-ui/react-toggle": "^1.1.9",
+        "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.6",
         "@turf/turf": "^7.2.0",
         "@vite-pwa/astro": "^0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 4.2.0(@types/node@22.15.19)(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(jiti@1.21.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(terser@5.39.2)(yaml@2.7.0)
       '@astrojs/tailwind':
         specifier: ^5.1.5
-        version: 5.1.5(astro@5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@2.79.2)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@3.4.17)
+        version: 5.1.5(astro@5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@4.41.0)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@3.4.17)
       '@nanostores/persistent':
         specifier: ^0.10.2
         version: 0.10.2(nanostores@0.11.3)
@@ -47,6 +47,12 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-toggle':
+        specifier: ^1.1.9
+        version: 1.1.9(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-toggle-group':
+        specifier: ^1.1.10
+        version: 1.1.10(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.6
         version: 1.2.6(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -55,10 +61,10 @@ importers:
         version: 7.2.0
       '@vite-pwa/astro':
         specifier: ^0.5.0
-        version: 0.5.0(astro@5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@2.79.2)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0))(vite-plugin-pwa@0.21.1(vite@6.3.5(@types/node@22.15.19)(jiti@1.21.7)(terser@5.39.2)(yaml@2.7.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0))
+        version: 0.5.0(astro@5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@4.41.0)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0))(vite-plugin-pwa@0.21.1(vite@6.3.5(@types/node@22.15.19)(jiti@1.21.7)(terser@5.39.2)(yaml@2.7.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0))
       astro:
         specifier: ^5.7.13
-        version: 5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@2.79.2)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0)
+        version: 5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@4.41.0)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1828,6 +1834,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-roving-focus@1.1.10':
+    resolution: {integrity: sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-select@2.2.5':
     resolution: {integrity: sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA==}
     peerDependencies:
@@ -1888,6 +1907,32 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.10':
+    resolution: {integrity: sha512-kiU694Km3WFLTC75DdqgM/3Jauf3rD9wxeS9XtyWFKsBUeZA337lC+6uUazT7I1DhanZ5gyD5Stf8uf2dbQxOQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.9':
+    resolution: {integrity: sha512-ZoFkBBz9zv9GWer7wIjvdRxmh2wyc2oKWw6C6CseWd6/yq1DK/l5lJ+wnsmFwJZbBYqr02mrf8A2q/CVCuM3ZA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-tooltip@1.2.6':
@@ -5854,9 +5899,9 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/tailwind@5.1.5(astro@5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@2.79.2)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@3.4.17)':
+  '@astrojs/tailwind@5.1.5(astro@5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@4.41.0)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0))(tailwindcss@3.4.17)':
     dependencies:
-      astro: 5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@2.79.2)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0)
+      astro: 5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@4.41.0)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0)
       autoprefixer: 10.4.20(postcss@8.5.1)
       postcss: 8.5.1
       postcss-load-config: 4.0.2(postcss@8.5.1)
@@ -7441,6 +7486,23 @@ snapshots:
       '@types/react': 19.0.8
       '@types/react-dom': 19.0.3(@types/react@19.0.8)
 
+  '@radix-ui/react-roving-focus@1.1.10(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
+
   '@radix-ui/react-select@2.2.5(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/number': 1.1.1
@@ -7506,6 +7568,32 @@ snapshots:
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.8
+
+  '@radix-ui/react-toggle-group@1.1.10(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.8)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-roving-focus': 1.1.10(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-toggle': 1.1.9(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
+
+  '@radix-ui/react-toggle@1.1.9(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.8)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.8
+      '@types/react-dom': 19.0.3(@types/react@19.0.8)
 
   '@radix-ui/react-tooltip@1.2.6(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -7698,6 +7786,14 @@ snapshots:
       picomatch: 4.0.2
     optionalDependencies:
       rollup: 2.79.2
+
+  '@rollup/pluginutils@5.1.4(rollup@4.41.0)':
+    dependencies:
+      '@types/estree': 1.0.7
+      estree-walker: 2.0.2
+      picomatch: 4.0.2
+    optionalDependencies:
+      rollup: 4.41.0
 
   '@rollup/rollup-android-arm-eabi@4.34.1':
     optional: true
@@ -9136,9 +9232,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vite-pwa/astro@0.5.0(astro@5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@2.79.2)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0))(vite-plugin-pwa@0.21.1(vite@6.3.5(@types/node@22.15.19)(jiti@1.21.7)(terser@5.39.2)(yaml@2.7.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0))':
+  '@vite-pwa/astro@0.5.0(astro@5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@4.41.0)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0))(vite-plugin-pwa@0.21.1(vite@6.3.5(@types/node@22.15.19)(jiti@1.21.7)(terser@5.39.2)(yaml@2.7.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0))':
     dependencies:
-      astro: 5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@2.79.2)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0)
+      astro: 5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@4.41.0)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0)
       vite-plugin-pwa: 0.21.1(vite@6.3.5(@types/node@22.15.19)(jiti@1.21.7)(terser@5.39.2)(yaml@2.7.0))(workbox-build@7.3.0(@types/babel__core@7.20.5))(workbox-window@7.3.0)
 
   '@vitejs/plugin-react@4.3.4(vite@6.0.11(@types/node@22.15.19)(jiti@1.21.7)(terser@5.39.2)(yaml@2.7.0))':
@@ -9313,7 +9409,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  astro@5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@2.79.2)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0):
+  astro@5.7.13(@types/node@22.15.19)(jiti@1.21.7)(rollup@4.41.0)(terser@5.39.2)(typescript@5.7.3)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.12.0
       '@astrojs/internal-helpers': 0.6.1
@@ -9321,7 +9417,7 @@ snapshots:
       '@astrojs/telemetry': 3.2.1
       '@capsizecss/unpack': 2.4.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.4(rollup@2.79.2)
+      '@rollup/pluginutils': 5.1.4(rollup@4.41.0)
       acorn: 8.14.1
       aria-query: 5.3.2
       axobject-query: 4.1.0

--- a/src/components/DraggableMarkers.tsx
+++ b/src/components/DraggableMarkers.tsx
@@ -99,8 +99,7 @@ const ColoredMarker = ({
                                             longitude ?? $hiderMode.longitude,
                                     });
                                 }}
-                                latLabel="Hider Latitude"
-                                lngLabel="Hider Longitude"
+                                label="Hider Location"
                             />
                         </SidebarMenu>
                     </>

--- a/src/components/DraggableMarkers.tsx
+++ b/src/components/DraggableMarkers.tsx
@@ -20,7 +20,6 @@ import {
 } from "./QuestionCards";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { useState } from "react";
-import { Button } from "./ui/button";
 import { SidebarMenu } from "./ui/sidebar-l";
 import { LatitudeLongitude } from "./LatLngPicker";
 
@@ -116,7 +115,6 @@ const ColoredMarker = ({
                                         data={q.data}
                                         questionKey={q.key}
                                         sub={sub}
-                                        showDeleteButton={false}
                                     />
                                 );
                             case "tentacles":
@@ -126,7 +124,6 @@ const ColoredMarker = ({
                                         data={q.data}
                                         questionKey={q.key}
                                         sub={sub}
-                                        showDeleteButton={false}
                                     />
                                 );
                             case "thermometer":
@@ -136,7 +133,6 @@ const ColoredMarker = ({
                                         data={q.data}
                                         questionKey={q.key}
                                         sub={sub}
-                                        showDeleteButton={false}
                                     />
                                 );
                             case "matching":
@@ -146,7 +142,6 @@ const ColoredMarker = ({
                                         data={q.data}
                                         questionKey={q.key}
                                         sub={sub}
-                                        showDeleteButton={false}
                                     />
                                 );
                             case "measuring":
@@ -156,7 +151,6 @@ const ColoredMarker = ({
                                         data={q.data}
                                         questionKey={q.key}
                                         sub={sub}
-                                        showDeleteButton={false}
                                     />
                                 );
                             default:
@@ -164,21 +158,6 @@ const ColoredMarker = ({
                         }
                     })}
 
-                <Button
-                    onClick={() => {
-                        if (questionKey === -1) {
-                            hiderMode.set(false);
-                        } else {
-                            questions.set(
-                                $questions.filter((q) => q.key !== questionKey),
-                            );
-                        }
-                    }}
-                    variant="destructive"
-                    className="font-semibold font-poppins"
-                >
-                    {questionKey === -1 ? "Disable" : "Delete"}
-                </Button>
                 {!$autoSave && (
                     <button
                         onClick={save}

--- a/src/components/DraggableMarkers.tsx
+++ b/src/components/DraggableMarkers.tsx
@@ -91,6 +91,7 @@ const ColoredMarker = ({
                             <LatitudeLongitude
                                 latitude={$hiderMode.latitude}
                                 longitude={$hiderMode.longitude}
+                                inlineEdit
                                 onChange={(latitude, longitude) => {
                                     hiderMode.set({
                                         latitude:

--- a/src/components/DraggableMarkers.tsx
+++ b/src/components/DraggableMarkers.tsx
@@ -20,6 +20,7 @@ import {
 } from "./QuestionCards";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { useState } from "react";
+import { Button } from "./ui/button";
 import { SidebarMenu } from "./ui/sidebar-l";
 import { LatitudeLongitude } from "./LatLngPicker";
 
@@ -157,7 +158,17 @@ const ColoredMarker = ({
                                 return null;
                         }
                     })}
-
+                {questionKey === -1 && (
+                    <Button // If it's the hider mode marker
+                        onClick={() => {
+                            hiderMode.set(false);
+                        }}
+                        variant="destructive"
+                        className="font-semibold font-poppins"
+                    >
+                        Disable
+                    </Button>
+                )}
                 {!$autoSave && (
                     <button
                         onClick={save}

--- a/src/components/LatLngPicker.tsx
+++ b/src/components/LatLngPicker.tsx
@@ -155,7 +155,7 @@ const LatLngEditForm = ({
                 </CommandList>
             </Command>
             <div className="flex gap-2 items-center">
-                <Label>Latitude</Label>
+                <Label className="min-w-16">Latitude</Label>
                 <Input
                     type="number"
                     value={Math.abs(latitude)}
@@ -180,7 +180,7 @@ const LatLngEditForm = ({
                 </Button>
             </div>
             <div className="flex gap-2 items-center">
-                <Label>Longitude</Label>
+                <Label className="min-w-16">Longitude</Label>
                 <Input
                     type="number"
                     value={Math.abs(longitude)}

--- a/src/components/LatLngPicker.tsx
+++ b/src/components/LatLngPicker.tsx
@@ -97,7 +97,7 @@ export const LatitudeLongitude = ({
     return (
         <>
             <SidebarMenuItem
-                className="p-2 rounded-md space-y-1"
+                className="p-2 rounded-md space-y-1 mt-2"
                 style={{
                     backgroundColor: color,
                 }}
@@ -210,6 +210,49 @@ export const LatitudeLongitude = ({
                     <Button
                         variant="outline"
                         onClick={() => {
+                            if (!navigator || !navigator.geolocation)
+                                return alert("Geolocation not supported");
+
+                            isLoading.set(true);
+
+                            toast.promise(
+                                new Promise<GeolocationPosition>(
+                                    (resolve, reject) => {
+                                        navigator.geolocation.getCurrentPosition(
+                                            resolve,
+                                            reject,
+                                            {
+                                                maximumAge: 0,
+                                                enableHighAccuracy: true,
+                                            },
+                                        );
+                                    },
+                                )
+                                    .then((position) => {
+                                        onChange(
+                                            position.coords.latitude,
+                                            position.coords.longitude,
+                                        );
+                                    })
+                                    .finally(() => {
+                                        isLoading.set(false);
+                                    }),
+                                {
+                                    pending: "Fetching location",
+                                    success: "Location fetched",
+                                    error: "Could not fetch location",
+                                },
+                                { autoClose: 500 },
+                            );
+                        }}
+                        disabled={disabled}
+                        title="Set to current location"
+                    >
+                        <LocateIcon />
+                    </Button>
+                    <Button
+                        variant="outline"
+                        onClick={() => {
                             if (!navigator || !navigator.clipboard) {
                                 toast.error(
                                     "Clipboard API not supported in your browser",
@@ -251,49 +294,6 @@ export const LatitudeLongitude = ({
                         title="Paste coordinates from clipboard"
                     >
                         <ClipboardPasteIcon />
-                    </Button>
-                    <Button
-                        variant="outline"
-                        onClick={() => {
-                            if (!navigator || !navigator.geolocation)
-                                return alert("Geolocation not supported");
-
-                            isLoading.set(true);
-
-                            toast.promise(
-                                new Promise<GeolocationPosition>(
-                                    (resolve, reject) => {
-                                        navigator.geolocation.getCurrentPosition(
-                                            resolve,
-                                            reject,
-                                            {
-                                                maximumAge: 0,
-                                                enableHighAccuracy: true,
-                                            },
-                                        );
-                                    },
-                                )
-                                    .then((position) => {
-                                        onChange(
-                                            position.coords.latitude,
-                                            position.coords.longitude,
-                                        );
-                                    })
-                                    .finally(() => {
-                                        isLoading.set(false);
-                                    }),
-                                {
-                                    pending: "Fetching location",
-                                    success: "Location fetched",
-                                    error: "Could not fetch location",
-                                },
-                                { autoClose: 500 },
-                            );
-                        }}
-                        disabled={disabled}
-                        title="Set to current location"
-                    >
-                        <LocateIcon />
                     </Button>
                     <Button
                         variant="outline"

--- a/src/components/LatLngPicker.tsx
+++ b/src/components/LatLngPicker.tsx
@@ -138,7 +138,9 @@ export const LatitudeLongitude = ({
                         </DialogTrigger>
                         <DialogContent>
                             <DialogHeader>
-                                <DialogTitle className="text-2xl">Update {label}</DialogTitle>
+                                <DialogTitle className="text-2xl">
+                                    Update {label}
+                                </DialogTitle>
                             </DialogHeader>
                             <div className="flex gap-2 items-center">
                                 <Label>Latitude</Label>

--- a/src/components/LatLngPicker.tsx
+++ b/src/components/LatLngPicker.tsx
@@ -1,13 +1,25 @@
 import { toast } from "react-toastify";
-import {
-    MENU_ITEM_CLASSNAME,
-    SidebarMenuButton,
-    SidebarMenuItem,
-} from "./ui/sidebar-l";
+import { SidebarMenuItem } from "./ui/sidebar-l";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { isLoading } from "@/lib/context";
 import { Button } from "./ui/button";
+import {
+    ClipboardCopyIcon,
+    ClipboardPasteIcon,
+    EditIcon,
+    LocateIcon,
+} from "lucide-react";
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from "./ui/dialog";
+import { iconColors } from "@/maps/api.ts";
 
 const parseCoordinatesFromText = (
     text: string,
@@ -66,189 +78,243 @@ export const LatitudeLongitude = ({
     latitude,
     longitude,
     onChange,
-    latLabel = "Latitude",
-    lngLabel = "Longitude",
+    label = "Location",
+    colorName,
     children,
     disabled,
 }: {
     latitude: number;
     longitude: number;
     onChange: (lat: number | null, lng: number | null) => void;
-    latLabel?: string;
-    lngLabel?: string;
+    label?: string;
+    colorName?: string;
     className?: string;
     children?: React.ReactNode;
     disabled?: boolean;
 }) => {
+    const color = iconColors[colorName];
+
     return (
         <>
-            <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
-                <Label className="leading-5">{latLabel}</Label>
-                <Input
-                    type="number"
-                    value={Math.abs(latitude)}
-                    min={0}
-                    max={90}
-                    onChange={(e) => {
-                        if (isNaN(parseFloat(e.target.value))) return;
-
-                        onChange(
-                            parseFloat(e.target.value) *
-                                (latitude !== 0 ? Math.sign(latitude) : -1),
-                            null,
-                        );
+            <SidebarMenuItem
+                className="p-2 rounded-md space-y-1"
+                style={{
+                    backgroundColor: color,
+                }}
+            >
+                <div
+                    className="flex justify-between items-center"
+                    style={{
+                        color: colorName === "gold" ? "black" : undefined,
                     }}
-                    disabled={disabled}
-                />
-                <Button
-                    variant="outline"
-                    onClick={() => onChange(-latitude, null)}
-                    disabled={disabled}
                 >
-                    {latitude > 0 ? "N" : "S"}
-                </Button>
-            </SidebarMenuItem>
-            <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
-                <Label className="leading-5">{lngLabel}</Label>
-                <Input
-                    type="number"
-                    value={Math.abs(longitude)}
-                    min={0}
-                    max={180}
-                    onChange={(e) => {
-                        if (isNaN(parseFloat(e.target.value))) return;
+                    <div className="text-2xl font-semibold font-poppins">
+                        {label}
+                    </div>
+                    <div className="tabular-nums text-right text-sm">
+                        <div>
+                            {Math.abs(latitude).toFixed(5)}
+                            {"° "}
+                            {latitude > 0 ? "N" : "S"}
+                        </div>
+                        <div>
+                            {Math.abs(longitude).toFixed(5)}
+                            {"° "}
+                            {longitude > 0 ? "E" : "W"}
+                        </div>
+                    </div>
+                </div>
 
-                        onChange(
-                            null,
-                            parseFloat(e.target.value) *
-                                (longitude !== 0 ? Math.sign(longitude) : -1),
-                        );
-                    }}
-                    disabled={disabled}
-                />
-                <Button
-                    variant="outline"
-                    onClick={() => onChange(null, -longitude)}
-                    disabled={disabled}
-                >
-                    {longitude > 0 ? "E" : "W"}
-                </Button>
-            </SidebarMenuItem>
-            <SidebarMenuItem className="flex gap-2">
-                <SidebarMenuButton
-                    className="bg-blue-600 p-2 rounded-md font-semibold font-poppins transition-colors duration-500 flex justify-center"
-                    onClick={() => {
-                        if (!navigator || !navigator.geolocation)
-                            return alert("Geolocation not supported");
+                <div className="flex justify-between gap-2">
+                    <Dialog>
+                        <DialogTrigger asChild>
+                            <Button disabled={disabled} variant="outline">
+                                <EditIcon />
+                            </Button>
+                        </DialogTrigger>
+                        <DialogContent>
+                            <DialogHeader>
+                                <DialogTitle>Update {label}</DialogTitle>
+                            </DialogHeader>
+                            <div className="flex gap-2 items-center">
+                                <Label>Latitude</Label>
+                                <Input
+                                    type="number"
+                                    value={Math.abs(latitude)}
+                                    min={0}
+                                    max={90}
+                                    onChange={(e) => {
+                                        if (isNaN(parseFloat(e.target.value)))
+                                            return;
 
-                        isLoading.set(true);
+                                        onChange(
+                                            parseFloat(e.target.value) *
+                                                (latitude !== 0
+                                                    ? Math.sign(latitude)
+                                                    : -1),
+                                            null,
+                                        );
+                                    }}
+                                    disabled={disabled}
+                                />
+                                <Button
+                                    variant="outline"
+                                    onClick={() => onChange(-latitude, null)}
+                                    disabled={disabled}
+                                >
+                                    {latitude > 0 ? "N" : "S"}
+                                </Button>
+                            </div>
+                            <div className="flex gap-2 items-center">
+                                <Label>Longitude</Label>
+                                <Input
+                                    type="number"
+                                    value={Math.abs(longitude)}
+                                    min={0}
+                                    max={180}
+                                    onChange={(e) => {
+                                        if (isNaN(parseFloat(e.target.value)))
+                                            return;
 
-                        toast.promise(
-                            new Promise<GeolocationPosition>(
-                                (resolve, reject) => {
-                                    navigator.geolocation.getCurrentPosition(
-                                        resolve,
-                                        reject,
-                                        {
-                                            maximumAge: 0,
-                                            enableHighAccuracy: true,
-                                        },
-                                    );
+                                        onChange(
+                                            null,
+                                            parseFloat(e.target.value) *
+                                                (longitude !== 0
+                                                    ? Math.sign(longitude)
+                                                    : -1),
+                                        );
+                                    }}
+                                    disabled={disabled}
+                                />
+                                <Button
+                                    variant="outline"
+                                    onClick={() => onChange(null, -longitude)}
+                                    disabled={disabled}
+                                >
+                                    {longitude > 0 ? "E" : "W"}
+                                </Button>
+                            </div>
+                            <DialogFooter>
+                                <DialogClose asChild>
+                                    <Button>Done</Button>
+                                </DialogClose>
+                            </DialogFooter>
+                        </DialogContent>
+                    </Dialog>
+                    <Button
+                        variant="outline"
+                        onClick={() => {
+                            if (!navigator || !navigator.clipboard) {
+                                toast.error(
+                                    "Clipboard API not supported in your browser",
+                                );
+                                return;
+                            }
+
+                            isLoading.set(true);
+
+                            toast.promise(
+                                navigator.clipboard
+                                    .readText()
+                                    .then((text) => {
+                                        const coords =
+                                            parseCoordinatesFromText(text);
+                                        if (
+                                            coords.lat !== null &&
+                                            coords.lng !== null
+                                        ) {
+                                            onChange(coords.lat, coords.lng);
+                                            return;
+                                        }
+                                        throw new Error(
+                                            "Could not find coordinates in clipboard content",
+                                        );
+                                    })
+                                    .finally(() => {
+                                        isLoading.set(false);
+                                    }),
+                                {
+                                    pending: "Reading from clipboard",
+                                    success: "Coordinates set from clipboard",
+                                    error: "No valid coordinates found in clipboard",
                                 },
-                            )
-                                .then((position) => {
-                                    onChange(
-                                        position.coords.latitude,
-                                        position.coords.longitude,
-                                    );
-                                })
-                                .finally(() => {
-                                    isLoading.set(false);
-                                }),
-                            {
-                                pending: "Fetching location",
-                                success: "Location fetched",
-                                error: "Could not fetch location",
-                            },
-                            { autoClose: 500 },
-                        );
-                    }}
-                    disabled={disabled}
-                >
-                    Current
-                </SidebarMenuButton>
-                <SidebarMenuButton
-                    className="bg-blue-600 p-2 rounded-md font-semibold font-poppins transition-colors duration-500 flex justify-center"
-                    onClick={() => {
-                        if (!navigator || !navigator.clipboard) {
-                            toast.error(
-                                "Clipboard API not supported in your browser",
+                                { autoClose: 1000 },
                             );
-                            return;
-                        }
+                        }}
+                        disabled={disabled}
+                    >
+                        <ClipboardPasteIcon />
+                    </Button>
+                    <Button
+                        variant="outline"
+                        onClick={() => {
+                            if (!navigator || !navigator.geolocation)
+                                return alert("Geolocation not supported");
 
-                        toast.promise(
-                            navigator.clipboard.writeText(
-                                `${Math.abs(latitude)}°${latitude > 0 ? "N" : "S"}, ${Math.abs(
-                                    longitude,
-                                )}°${longitude > 0 ? "E" : "W"}`,
-                            ),
-                            {
-                                pending: "Writing to clipboard...",
-                                success: "Coordinates copied!",
-                                error: "An error occurred while copying",
-                            },
-                            { autoClose: 1000 },
-                        );
-                    }}
-                    disabled={disabled}
-                >
-                    Copy
-                </SidebarMenuButton>
-                <SidebarMenuButton
-                    className="bg-blue-600 p-2 rounded-md font-semibold font-poppins transition-colors duration-500 flex justify-center"
-                    onClick={() => {
-                        if (!navigator || !navigator.clipboard) {
-                            toast.error(
-                                "Clipboard API not supported in your browser",
+                            isLoading.set(true);
+
+                            toast.promise(
+                                new Promise<GeolocationPosition>(
+                                    (resolve, reject) => {
+                                        navigator.geolocation.getCurrentPosition(
+                                            resolve,
+                                            reject,
+                                            {
+                                                maximumAge: 0,
+                                                enableHighAccuracy: true,
+                                            },
+                                        );
+                                    },
+                                )
+                                    .then((position) => {
+                                        onChange(
+                                            position.coords.latitude,
+                                            position.coords.longitude,
+                                        );
+                                    })
+                                    .finally(() => {
+                                        isLoading.set(false);
+                                    }),
+                                {
+                                    pending: "Fetching location",
+                                    success: "Location fetched",
+                                    error: "Could not fetch location",
+                                },
+                                { autoClose: 500 },
                             );
-                            return;
-                        }
+                        }}
+                        disabled={disabled}
+                    >
+                        <LocateIcon />
+                    </Button>
+                    <Button
+                        variant="outline"
+                        onClick={() => {
+                            if (!navigator || !navigator.clipboard) {
+                                toast.error(
+                                    "Clipboard API not supported in your browser",
+                                );
+                                return;
+                            }
 
-                        isLoading.set(true);
-
-                        toast.promise(
-                            navigator.clipboard
-                                .readText()
-                                .then((text) => {
-                                    const coords =
-                                        parseCoordinatesFromText(text);
-                                    if (
-                                        coords.lat !== null &&
-                                        coords.lng !== null
-                                    ) {
-                                        onChange(coords.lat, coords.lng);
-                                        return;
-                                    }
-                                    throw new Error(
-                                        "Could not find coordinates in clipboard content",
-                                    );
-                                })
-                                .finally(() => {
-                                    isLoading.set(false);
-                                }),
-                            {
-                                pending: "Reading from clipboard",
-                                success: "Coordinates set from clipboard",
-                                error: "No valid coordinates found in clipboard",
-                            },
-                            { autoClose: 1000 },
-                        );
-                    }}
-                    disabled={disabled}
-                >
-                    Paste
-                </SidebarMenuButton>
+                            toast.promise(
+                                navigator.clipboard.writeText(
+                                    `${Math.abs(latitude)}°${latitude > 0 ? "N" : "S"}, ${Math.abs(
+                                        longitude,
+                                    )}°${longitude > 0 ? "E" : "W"}`,
+                                ),
+                                {
+                                    pending: "Writing to clipboard...",
+                                    success: "Coordinates copied!",
+                                    error: "An error occurred while copying",
+                                },
+                                { autoClose: 1000 },
+                            );
+                        }}
+                    >
+                        <ClipboardCopyIcon />
+                    </Button>
+                </div>
             </SidebarMenuItem>
             {children}
         </>

--- a/src/components/LatLngPicker.tsx
+++ b/src/components/LatLngPicker.tsx
@@ -128,7 +128,11 @@ export const LatitudeLongitude = ({
                 <div className="flex justify-between gap-2">
                     <Dialog>
                         <DialogTrigger asChild>
-                            <Button disabled={disabled} variant="outline">
+                            <Button
+                                disabled={disabled}
+                                variant="outline"
+                                title="Edit coordinates"
+                            >
                                 <EditIcon />
                             </Button>
                         </DialogTrigger>
@@ -242,6 +246,7 @@ export const LatitudeLongitude = ({
                             );
                         }}
                         disabled={disabled}
+                        title="Paste coordinates from clipboard"
                     >
                         <ClipboardPasteIcon />
                     </Button>
@@ -284,6 +289,7 @@ export const LatitudeLongitude = ({
                             );
                         }}
                         disabled={disabled}
+                        title="Set to current location"
                     >
                         <LocateIcon />
                     </Button>
@@ -311,6 +317,7 @@ export const LatitudeLongitude = ({
                                 { autoClose: 1000 },
                             );
                         }}
+                        title="Copy coordinates to clipboard"
                     >
                         <ClipboardCopyIcon />
                     </Button>

--- a/src/components/LatLngPicker.tsx
+++ b/src/components/LatLngPicker.tsx
@@ -87,12 +87,12 @@ export const LatitudeLongitude = ({
     longitude: number;
     onChange: (lat: number | null, lng: number | null) => void;
     label?: string;
-    colorName?: string;
+    colorName?: keyof typeof iconColors;
     className?: string;
     children?: React.ReactNode;
     disabled?: boolean;
 }) => {
-    const color = iconColors[colorName];
+    const color = colorName ? iconColors[colorName] : "transparent";
 
     return (
         <>

--- a/src/components/LatLngPicker.tsx
+++ b/src/components/LatLngPicker.tsx
@@ -198,7 +198,7 @@ export const LatitudeLongitude = ({
                 <div
                     className={cn(
                         !inlineEdit &&
-                            "flex justify-between gap-2 *:max-w-12 *:w-[20%]",
+                            "flex justify-center gap-2 *:max-w-12 *:w-[20%]",
                     )}
                 >
                     {inlineEdit ? (
@@ -241,7 +241,13 @@ export const LatitudeLongitude = ({
                             </DialogContent>
                         </Dialog>
                     )}
-                    <div className={inlineEdit ? "flex justify-center gap-2" : "contents"}>
+                    <div
+                        className={
+                            inlineEdit
+                                ? "flex justify-center gap-2"
+                                : "contents"
+                        }
+                    >
                         <Button
                             variant="outline"
                             onClick={() => {

--- a/src/components/LatLngPicker.tsx
+++ b/src/components/LatLngPicker.tsx
@@ -111,7 +111,7 @@ export const LatitudeLongitude = ({
                     <div className="text-2xl font-semibold font-poppins">
                         {label}
                     </div>
-                    <div className="tabular-nums text-right text-sm">
+                    <div className="tabular-nums text-right text-sm font-oxygen">
                         <div>
                             {Math.abs(latitude).toFixed(5)}
                             {"° "}
@@ -125,7 +125,7 @@ export const LatitudeLongitude = ({
                     </div>
                 </div>
 
-                <div className="flex justify-between gap-2">
+                <div className="flex justify-between gap-2 *:max-w-12 *:w-[20%]">
                     <Dialog>
                         <DialogTrigger asChild>
                             <Button
@@ -138,7 +138,7 @@ export const LatitudeLongitude = ({
                         </DialogTrigger>
                         <DialogContent>
                             <DialogHeader>
-                                <DialogTitle>Update {label}</DialogTitle>
+                                <DialogTitle className="text-2xl">Update {label}</DialogTitle>
                             </DialogHeader>
                             <div className="flex gap-2 items-center">
                                 <Label>Latitude</Label>

--- a/src/components/LatLngPicker.tsx
+++ b/src/components/LatLngPicker.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/command";
 import { useDebounce } from "@/hooks/useDebounce";
 import { geocode, determineName } from "@/maps/api";
+import { useStore } from "@nanostores/react";
 
 const parseCoordinatesFromText = (
     text: string,
@@ -228,19 +229,24 @@ export const LatitudeLongitude = ({
     disabled?: boolean;
     inlineEdit?: boolean;
 }) => {
+    const $isLoading = useStore(isLoading);
+
     const color = colorName ? iconColors[colorName] : "transparent";
 
     return (
         <>
             <SidebarMenuItem
-                className="p-2 rounded-md space-y-1 mt-2"
                 style={{
                     backgroundColor: color,
                 }}
+                className={cn("p-2 rounded-md space-y-1 mt-2", $isLoading && "brightness-50")}
             >
                 {!inlineEdit && (
                     <div
-                        className="flex justify-between items-center"
+                        className={cn(
+                            "flex justify-between items-center",
+                            $isLoading && "opacity-50",
+                        )}
                         style={{
                             color: colorName === "gold" ? "black" : undefined,
                         }}

--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -510,8 +510,7 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                                                 );
                                             }
                                         }}
-                                        latLabel="Hider Latitude"
-                                        lngLabel="Hider Longitude"
+                                        label="Hider Location"
                                     />
                                     {!autoSave && (
                                         <SidebarMenuItem>

--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -493,6 +493,7 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                                     <LatitudeLongitude
                                         latitude={$hiderMode.latitude}
                                         longitude={$hiderMode.longitude}
+                                        inlineEdit
                                         onChange={(latitude, longitude) => {
                                             $hiderMode.latitude =
                                                 latitude ?? $hiderMode.latitude;

--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -141,9 +141,7 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
             }
 
             if (geojson.zoneOptions) {
-                displayHidingZonesOptions.set(
-                    geojson.zoneOptions ?? [],
-                );
+                displayHidingZonesOptions.set(geojson.zoneOptions ?? []);
             }
 
             toast.success("Hiding zone loaded successfully", {

--- a/src/components/PolygonDraw.tsx
+++ b/src/components/PolygonDraw.tsx
@@ -83,6 +83,7 @@ const TentacleMarker = ({
                         <LatitudeLongitude
                             latitude={point.geometry.coordinates[1]}
                             longitude={point.geometry.coordinates[0]}
+                            inlineEdit
                             onChange={(lat, lng) => {
                                 if (lat) {
                                     point.geometry.coordinates[1] = lat;
@@ -140,6 +141,7 @@ const MatchingPointMarker = ({
                         <LatitudeLongitude
                             latitude={point.geometry.coordinates[1]}
                             longitude={point.geometry.coordinates[0]}
+                            inlineEdit
                             onChange={(lat, lng) => {
                                 if (lat) {
                                     point.geometry.coordinates[1] = lat;
@@ -197,6 +199,7 @@ const MeasuringPointMarker = ({
                         <LatitudeLongitude
                             latitude={point.geometry.coordinates[1]}
                             longitude={point.geometry.coordinates[0]}
+                            inlineEdit
                             onChange={(lat, lng) => {
                                 if (lat) {
                                     point.geometry.coordinates[1] = lat;

--- a/src/components/cards/base.tsx
+++ b/src/components/cards/base.tsx
@@ -29,6 +29,8 @@ import {
     DialogDescription,
     DialogHeader,
 } from "../ui/dialog";
+import { Button } from "@/components/ui/button.tsx";
+import { LockIcon, UnlockIcon } from "lucide-react";
 
 export const QuestionCard = ({
     children,
@@ -38,6 +40,8 @@ export const QuestionCard = ({
     sub,
     showDeleteButton,
     collapsed,
+    locked,
+    setLocked,
     setCollapsed,
 }: {
     children: React.ReactNode;
@@ -47,6 +51,8 @@ export const QuestionCard = ({
     sub?: string;
     showDeleteButton?: boolean;
     collapsed?: boolean;
+    locked?: boolean;
+    setLocked?: (locked: boolean) => void;
     setCollapsed?: (collapsed: boolean) => void;
 }) => {
     const [isCollapsed, setIsCollapsed] = useState(collapsed ?? false);
@@ -63,84 +69,6 @@ export const QuestionCard = ({
         <>
             <SidebarGroup className={className}>
                 <div className="relative">
-                    <div className="absolute top-2 right-2 flex gap-2 justify-end text-white">
-                        <Dialog>
-                            <DialogTrigger>
-                                <VscShare />
-                            </DialogTrigger>
-                            <DialogContent>
-                                <DialogHeader>
-                                    <DialogTitle className="text-2xl">
-                                        Share this Question!
-                                    </DialogTitle>
-                                    <DialogDescription>
-                                        Below you can access the JSON
-                                        representing the question. Send this to
-                                        another player for them to copy. They
-                                        can then click &ldquo;Paste
-                                        Question&rdquo; at the bottom of the
-                                        &ldquo;Questions&rdquo; sidebar.
-                                    </DialogDescription>
-                                </DialogHeader>
-                                <textarea
-                                    className="w-full h-[300px] bg-slate-900 text-white rounded-md p-2"
-                                    readOnly
-                                    value={JSON.stringify(
-                                        $questions.find(
-                                            (q) => q.key === questionKey,
-                                        ),
-                                        null,
-                                        4,
-                                    )}
-                                ></textarea>
-                            </DialogContent>
-                        </Dialog>
-                        {showDeleteButton && (
-                            <AlertDialog>
-                                <AlertDialogTrigger>
-                                    <VscTrash />
-                                </AlertDialogTrigger>
-                                <AlertDialogContent>
-                                    <AlertDialogHeader>
-                                        <AlertDialogTitle>
-                                            Are you absolutely sure?
-                                        </AlertDialogTitle>
-                                        <AlertDialogDescription>
-                                            This action cannot be undone. This
-                                            will permanently delete the
-                                            question.
-                                        </AlertDialogDescription>
-                                    </AlertDialogHeader>
-                                    <AlertDialogFooter>
-                                        <AlertDialogCancel>
-                                            Cancel
-                                        </AlertDialogCancel>
-                                        <AlertDialogAction
-                                            onClick={() => {
-                                                questions.set([]);
-                                            }}
-                                        >
-                                            Delete All Questions
-                                        </AlertDialogAction>
-                                        <AlertDialogAction
-                                            onClick={() => {
-                                                questions.set(
-                                                    $questions.filter(
-                                                        (q) =>
-                                                            q.key !==
-                                                            questionKey,
-                                                    ),
-                                                );
-                                            }}
-                                            className="mb-2 sm:mb-0"
-                                        >
-                                            Delete Question
-                                        </AlertDialogAction>
-                                    </AlertDialogFooter>
-                                </AlertDialogContent>
-                            </AlertDialog>
-                        )}
-                    </div>
                     <button
                         onClick={toggleCollapse}
                         className={cn(
@@ -161,6 +89,95 @@ export const QuestionCard = ({
                     >
                         <SidebarMenu>{children}</SidebarMenu>
                     </SidebarGroupContent>
+                </div>
+
+                <div className="flex gap-2 pt-2 px-2">
+                    <Dialog>
+                        <DialogTrigger asChild>
+                            <Button variant="outline" size="sm">
+                                <VscShare />
+                            </Button>
+                        </DialogTrigger>
+                        <DialogContent>
+                            <DialogHeader>
+                                <DialogTitle className="text-2xl">
+                                    Share this Question!
+                                </DialogTitle>
+                                <DialogDescription>
+                                    Below you can access the JSON representing
+                                    the question. Send this to another player
+                                    for them to copy. They can then click
+                                    &ldquo;Paste Question&rdquo; at the bottom
+                                    of the &ldquo;Questions&rdquo; sidebar.
+                                </DialogDescription>
+                            </DialogHeader>
+                            <textarea
+                                className="w-full h-[300px] bg-slate-900 text-white rounded-md p-2"
+                                readOnly
+                                value={JSON.stringify(
+                                    $questions.find(
+                                        (q) => q.key === questionKey,
+                                    ),
+                                    null,
+                                    4,
+                                )}
+                            ></textarea>
+                        </DialogContent>
+                    </Dialog>
+                    {showDeleteButton && (
+                        <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                                <Button variant="outline" size="sm">
+                                    <VscTrash />
+                                </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                                <AlertDialogHeader>
+                                    <AlertDialogTitle>
+                                        Are you absolutely sure?
+                                    </AlertDialogTitle>
+                                    <AlertDialogDescription>
+                                        This action cannot be undone. This will
+                                        permanently delete the question.
+                                    </AlertDialogDescription>
+                                </AlertDialogHeader>
+                                <AlertDialogFooter>
+                                    <AlertDialogCancel>
+                                        Cancel
+                                    </AlertDialogCancel>
+                                    <AlertDialogAction
+                                        onClick={() => {
+                                            questions.set([]);
+                                        }}
+                                    >
+                                        Delete All Questions
+                                    </AlertDialogAction>
+                                    <AlertDialogAction
+                                        onClick={() => {
+                                            questions.set(
+                                                $questions.filter(
+                                                    (q) =>
+                                                        q.key !== questionKey,
+                                                ),
+                                            );
+                                        }}
+                                        className="mb-2 sm:mb-0"
+                                    >
+                                        Delete Question
+                                    </AlertDialogAction>
+                                </AlertDialogFooter>
+                            </AlertDialogContent>
+                        </AlertDialog>
+                    )}
+                    {locked !== undefined && (
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setLocked!(!locked)}
+                        >
+                            {locked ? <LockIcon /> : <UnlockIcon />}
+                        </Button>
+                    )}
                 </div>
             </SidebarGroup>
             <Separator className="h-1" />

--- a/src/components/cards/base.tsx
+++ b/src/components/cards/base.tsx
@@ -2,7 +2,7 @@ import { VscChevronDown, VscShare, VscTrash } from "react-icons/vsc";
 import { useState } from "react";
 import { useStore } from "@nanostores/react";
 import { cn } from "@/lib/utils";
-import { questions } from "@/lib/context";
+import { isLoading, questions } from "@/lib/context";
 import {
     SidebarGroup,
     SidebarGroupContent,
@@ -55,6 +55,7 @@ export const QuestionCard = ({
 }) => {
     const [isCollapsed, setIsCollapsed] = useState(collapsed ?? false);
     const $questions = useStore(questions);
+    const $isLoading = useStore(isLoading);
 
     const toggleCollapse = () => {
         if (setCollapsed) {
@@ -125,7 +126,11 @@ export const QuestionCard = ({
                             </Dialog>
                             <AlertDialog>
                                 <AlertDialogTrigger asChild>
-                                    <Button variant="outline" size="sm">
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        disabled={$isLoading}
+                                    >
                                         <VscTrash />
                                     </Button>
                                 </AlertDialogTrigger>
@@ -173,6 +178,7 @@ export const QuestionCard = ({
                                     variant="outline"
                                     size="sm"
                                     onClick={() => setLocked!(!locked)}
+                                    disabled={$isLoading}
                                 >
                                     {locked ? <LockIcon /> : <UnlockIcon />}
                                 </Button>

--- a/src/components/cards/base.tsx
+++ b/src/components/cards/base.tsx
@@ -88,96 +88,98 @@ export const QuestionCard = ({
                         )}
                     >
                         <SidebarMenu>{children}</SidebarMenu>
-                    </SidebarGroupContent>
-                </div>
-
-                <div className="flex gap-2 pt-2 px-2 justify-center">
-                    <Dialog>
-                        <DialogTrigger asChild>
-                            <Button variant="outline" size="sm">
-                                <VscShare />
-                            </Button>
-                        </DialogTrigger>
-                        <DialogContent>
-                            <DialogHeader>
-                                <DialogTitle className="text-2xl">
-                                    Share this Question!
-                                </DialogTitle>
-                                <DialogDescription>
-                                    Below you can access the JSON representing
-                                    the question. Send this to another player
-                                    for them to copy. They can then click
-                                    &ldquo;Paste Question&rdquo; at the bottom
-                                    of the &ldquo;Questions&rdquo; sidebar.
-                                </DialogDescription>
-                            </DialogHeader>
-                            <textarea
-                                className="w-full h-[300px] bg-slate-900 text-white rounded-md p-2"
-                                readOnly
-                                value={JSON.stringify(
-                                    $questions.find(
-                                        (q) => q.key === questionKey,
-                                    ),
-                                    null,
-                                    4,
-                                )}
-                            ></textarea>
-                        </DialogContent>
-                    </Dialog>
-                    {showDeleteButton && (
-                        <AlertDialog>
-                            <AlertDialogTrigger asChild>
-                                <Button variant="outline" size="sm">
-                                    <VscTrash />
+                        <div className="flex gap-2 pt-2 px-2 justify-center">
+                            <Dialog>
+                                <DialogTrigger asChild>
+                                    <Button variant="outline" size="sm">
+                                        <VscShare />
+                                    </Button>
+                                </DialogTrigger>
+                                <DialogContent>
+                                    <DialogHeader>
+                                        <DialogTitle className="text-2xl">
+                                            Share this Question!
+                                        </DialogTitle>
+                                        <DialogDescription>
+                                            Below you can access the JSON
+                                            representing the question. Send this
+                                            to another player for them to copy.
+                                            They can then click &ldquo;Paste
+                                            Question&rdquo; at the bottom of the
+                                            &ldquo;Questions&rdquo; sidebar.
+                                        </DialogDescription>
+                                    </DialogHeader>
+                                    <textarea
+                                        className="w-full h-[300px] bg-slate-900 text-white rounded-md p-2"
+                                        readOnly
+                                        value={JSON.stringify(
+                                            $questions.find(
+                                                (q) => q.key === questionKey,
+                                            ),
+                                            null,
+                                            4,
+                                        )}
+                                    ></textarea>
+                                </DialogContent>
+                            </Dialog>
+                            {showDeleteButton && (
+                                <AlertDialog>
+                                    <AlertDialogTrigger asChild>
+                                        <Button variant="outline" size="sm">
+                                            <VscTrash />
+                                        </Button>
+                                    </AlertDialogTrigger>
+                                    <AlertDialogContent>
+                                        <AlertDialogHeader>
+                                            <AlertDialogTitle>
+                                                Are you absolutely sure?
+                                            </AlertDialogTitle>
+                                            <AlertDialogDescription>
+                                                This action cannot be undone.
+                                                This will permanently delete the
+                                                question.
+                                            </AlertDialogDescription>
+                                        </AlertDialogHeader>
+                                        <AlertDialogFooter>
+                                            <AlertDialogCancel>
+                                                Cancel
+                                            </AlertDialogCancel>
+                                            <AlertDialogAction
+                                                onClick={() => {
+                                                    questions.set([]);
+                                                }}
+                                            >
+                                                Delete All Questions
+                                            </AlertDialogAction>
+                                            <AlertDialogAction
+                                                onClick={() => {
+                                                    questions.set(
+                                                        $questions.filter(
+                                                            (q) =>
+                                                                q.key !==
+                                                                questionKey,
+                                                        ),
+                                                    );
+                                                }}
+                                                className="mb-2 sm:mb-0"
+                                            >
+                                                Delete Question
+                                            </AlertDialogAction>
+                                        </AlertDialogFooter>
+                                    </AlertDialogContent>
+                                </AlertDialog>
+                            )}
+                            {locked !== undefined && (
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() => setLocked!(!locked)}
+                                >
+                                    {locked ? <LockIcon /> : <UnlockIcon />}
                                 </Button>
-                            </AlertDialogTrigger>
-                            <AlertDialogContent>
-                                <AlertDialogHeader>
-                                    <AlertDialogTitle>
-                                        Are you absolutely sure?
-                                    </AlertDialogTitle>
-                                    <AlertDialogDescription>
-                                        This action cannot be undone. This will
-                                        permanently delete the question.
-                                    </AlertDialogDescription>
-                                </AlertDialogHeader>
-                                <AlertDialogFooter>
-                                    <AlertDialogCancel>
-                                        Cancel
-                                    </AlertDialogCancel>
-                                    <AlertDialogAction
-                                        onClick={() => {
-                                            questions.set([]);
-                                        }}
-                                    >
-                                        Delete All Questions
-                                    </AlertDialogAction>
-                                    <AlertDialogAction
-                                        onClick={() => {
-                                            questions.set(
-                                                $questions.filter(
-                                                    (q) =>
-                                                        q.key !== questionKey,
-                                                ),
-                                            );
-                                        }}
-                                        className="mb-2 sm:mb-0"
-                                    >
-                                        Delete Question
-                                    </AlertDialogAction>
-                                </AlertDialogFooter>
-                            </AlertDialogContent>
-                        </AlertDialog>
-                    )}
-                    {locked !== undefined && (
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setLocked!(!locked)}
-                        >
-                            {locked ? <LockIcon /> : <UnlockIcon />}
-                        </Button>
-                    )}
+                            )}
+                        </div>
+                    </SidebarGroupContent>
                 </div>
             </SidebarGroup>
             <Separator className="h-1" />

--- a/src/components/cards/base.tsx
+++ b/src/components/cards/base.tsx
@@ -38,7 +38,6 @@ export const QuestionCard = ({
     className,
     label,
     sub,
-    showDeleteButton,
     collapsed,
     locked,
     setLocked,
@@ -49,7 +48,6 @@ export const QuestionCard = ({
     className?: string;
     label?: string;
     sub?: string;
-    showDeleteButton?: boolean;
     collapsed?: boolean;
     locked?: boolean;
     setLocked?: (locked: boolean) => void;
@@ -122,53 +120,51 @@ export const QuestionCard = ({
                                     ></textarea>
                                 </DialogContent>
                             </Dialog>
-                            {showDeleteButton && (
-                                <AlertDialog>
-                                    <AlertDialogTrigger asChild>
-                                        <Button variant="outline" size="sm">
-                                            <VscTrash />
-                                        </Button>
-                                    </AlertDialogTrigger>
-                                    <AlertDialogContent>
-                                        <AlertDialogHeader>
-                                            <AlertDialogTitle>
-                                                Are you absolutely sure?
-                                            </AlertDialogTitle>
-                                            <AlertDialogDescription>
-                                                This action cannot be undone.
-                                                This will permanently delete the
-                                                question.
-                                            </AlertDialogDescription>
-                                        </AlertDialogHeader>
-                                        <AlertDialogFooter>
-                                            <AlertDialogCancel>
-                                                Cancel
-                                            </AlertDialogCancel>
-                                            <AlertDialogAction
-                                                onClick={() => {
-                                                    questions.set([]);
-                                                }}
-                                            >
-                                                Delete All Questions
-                                            </AlertDialogAction>
-                                            <AlertDialogAction
-                                                onClick={() => {
-                                                    questions.set(
-                                                        $questions.filter(
-                                                            (q) =>
-                                                                q.key !==
-                                                                questionKey,
-                                                        ),
-                                                    );
-                                                }}
-                                                className="mb-2 sm:mb-0"
-                                            >
-                                                Delete Question
-                                            </AlertDialogAction>
-                                        </AlertDialogFooter>
-                                    </AlertDialogContent>
-                                </AlertDialog>
-                            )}
+                            <AlertDialog>
+                                <AlertDialogTrigger asChild>
+                                    <Button variant="outline" size="sm">
+                                        <VscTrash />
+                                    </Button>
+                                </AlertDialogTrigger>
+                                <AlertDialogContent>
+                                    <AlertDialogHeader>
+                                        <AlertDialogTitle>
+                                            Are you absolutely sure?
+                                        </AlertDialogTitle>
+                                        <AlertDialogDescription>
+                                            This action cannot be undone. This
+                                            will permanently delete the
+                                            question.
+                                        </AlertDialogDescription>
+                                    </AlertDialogHeader>
+                                    <AlertDialogFooter>
+                                        <AlertDialogCancel>
+                                            Cancel
+                                        </AlertDialogCancel>
+                                        <AlertDialogAction
+                                            onClick={() => {
+                                                questions.set([]);
+                                            }}
+                                        >
+                                            Delete All Questions
+                                        </AlertDialogAction>
+                                        <AlertDialogAction
+                                            onClick={() => {
+                                                questions.set(
+                                                    $questions.filter(
+                                                        (q) =>
+                                                            q.key !==
+                                                            questionKey,
+                                                    ),
+                                                );
+                                            }}
+                                            className="mb-2 sm:mb-0"
+                                        >
+                                            Delete Question
+                                        </AlertDialogAction>
+                                    </AlertDialogFooter>
+                                </AlertDialogContent>
+                            </AlertDialog>
                             {locked !== undefined && (
                                 <Button
                                     variant="outline"

--- a/src/components/cards/base.tsx
+++ b/src/components/cards/base.tsx
@@ -76,7 +76,10 @@ export const QuestionCard = ({
                     >
                         <VscChevronDown />
                     </button>
-                    <SidebarGroupLabel className="ml-8 mr-8">
+                    <SidebarGroupLabel
+                        className="ml-8 mr-8 cursor-pointer"
+                        onClick={toggleCollapse}
+                    >
                         {label} {sub && `(${sub})`}
                     </SidebarGroupLabel>
                     <SidebarGroupContent

--- a/src/components/cards/base.tsx
+++ b/src/components/cards/base.tsx
@@ -91,7 +91,7 @@ export const QuestionCard = ({
                     </SidebarGroupContent>
                 </div>
 
-                <div className="flex gap-2 pt-2 px-2">
+                <div className="flex gap-2 pt-2 px-2 justify-center">
                     <Dialog>
                         <DialogTrigger asChild>
                             <Button variant="outline" size="sm">

--- a/src/components/cards/matching.tsx
+++ b/src/components/cards/matching.tsx
@@ -23,6 +23,8 @@ import { Checkbox } from "../ui/checkbox";
 import { QuestionCard } from "./base";
 import { determineMatchingBoundary, findMatchingPlaces } from "@/maps/matching";
 import { toast } from "react-toastify";
+import { Label } from "@/components/ui/label.tsx";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group.tsx";
 
 export const MatchingQuestionComponent = ({
     data,
@@ -162,6 +164,8 @@ export const MatchingQuestionComponent = ({
             setCollapsed={(collapsed) => {
                 data.collapsed = collapsed; // Doesn't trigger a re-render so no need for questionModified
             }}
+            locked={!data.drag}
+            setLocked={(locked) => questionModified((data.drag = !locked))}
         >
             <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
                 <Select
@@ -254,48 +258,12 @@ export const MatchingQuestionComponent = ({
                 />
             </SidebarMenuItem>
             {questionSpecific}
-            <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
-                <label className="text-2xl font-semibold font-poppins">
-                    Same
-                </label>
-                <Checkbox
-                    disabled={!!$hiderMode || !data.drag || $isLoading}
-                    checked={data.same}
-                    onCheckedChange={(checked) =>
-                        questionModified((data.same = checked as boolean))
-                    }
-                />
-            </SidebarMenuItem>
-            <SidebarMenuItem
-                className={cn(
-                    MENU_ITEM_CLASSNAME,
-                    "text-2xl font-semibold font-poppins",
-                    data.type === "custom-zone" && "capitalize",
-                )}
-                style={
-                    data.type === "custom-zone"
-                        ? {}
-                        : {
-                              backgroundColor: iconColors[data.color],
-                              color:
-                                  data.color === "gold" ? "black" : undefined,
-                          }
-                }
-            >
-                {data.type !== "custom-zone" && "Color ("} lock{" "}
-                <Checkbox
-                    checked={!data.drag}
-                    disabled={$isLoading}
-                    onCheckedChange={(checked) =>
-                        questionModified((data.drag = !checked as boolean))
-                    }
-                />
-                {data.type !== "custom-zone" && ")"}
-            </SidebarMenuItem>
+
             {data.type !== "custom-zone" && (
                 <LatitudeLongitude
                     latitude={data.lat}
                     longitude={data.lng}
+                    colorName={data.color}
                     onChange={(lat, lng) => {
                         if (lat !== null) {
                             data.lat = lat;
@@ -308,6 +276,23 @@ export const MatchingQuestionComponent = ({
                     disabled={!data.drag || $isLoading}
                 />
             )}
+            <div className="flex gap-2 items-center p-2">
+                <Label className="font-semibold text-lg">Result</Label>
+                <ToggleGroup
+                    className="grow"
+                    type="single"
+                    value={data.same ? "same" : "different"}
+                    onValueChange={(value) =>
+                        questionModified((data.same = value === "same"))
+                    }
+                    disabled={!!$hiderMode || !data.drag || $isLoading}
+                >
+                    <ToggleGroupItem value="different">
+                        Different
+                    </ToggleGroupItem>
+                    <ToggleGroupItem value="same">Same</ToggleGroupItem>
+                </ToggleGroup>
+            </div>
         </QuestionCard>
     );
 };

--- a/src/components/cards/matching.tsx
+++ b/src/components/cards/matching.tsx
@@ -1,6 +1,5 @@
 import { LatitudeLongitude } from "../LatLngPicker";
 import { useStore } from "@nanostores/react";
-import { cn } from "@/lib/utils";
 import {
     displayHidingZones,
     drawingQuestionKey,
@@ -10,7 +9,6 @@ import {
     questions,
     triggerLocalRefresh,
 } from "@/lib/context";
-import { iconColors } from "@/maps/api";
 import {
     determineUnionizedStrings,
     matchingQuestionSchema,
@@ -282,7 +280,7 @@ export const MatchingQuestionComponent = ({
                     className="grow"
                     type="single"
                     value={data.same ? "same" : "different"}
-                    onValueChange={(value) =>
+                    onValueChange={(value: "same" | "different") =>
                         questionModified((data.same = value === "same"))
                     }
                     disabled={!!$hiderMode || !data.drag || $isLoading}

--- a/src/components/cards/matching.tsx
+++ b/src/components/cards/matching.tsx
@@ -23,6 +23,7 @@ import { determineMatchingBoundary, findMatchingPlaces } from "@/maps/matching";
 import { toast } from "react-toastify";
 import { Label } from "@/components/ui/label.tsx";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group.tsx";
+import { cn } from "@/lib/utils";
 
 export const MatchingQuestionComponent = ({
     data,
@@ -272,7 +273,14 @@ export const MatchingQuestionComponent = ({
                 />
             )}
             <div className="flex gap-2 items-center p-2">
-                <Label className="font-semibold text-lg">Result</Label>
+                <Label
+                    className={cn(
+                        "font-semibold text-lg",
+                        $isLoading && "text-muted-foreground",
+                    )}
+                >
+                    Result
+                </Label>
                 <ToggleGroup
                     className="grow"
                     type="single"

--- a/src/components/cards/matching.tsx
+++ b/src/components/cards/matching.tsx
@@ -29,13 +29,11 @@ export const MatchingQuestionComponent = ({
     questionKey,
     sub,
     className,
-    showDeleteButton = true,
 }: {
     data: MatchingQuestion;
     questionKey: number;
     sub?: string;
     className?: string;
-    showDeleteButton?: boolean;
 }) => {
     useStore(triggerLocalRefresh);
     const $hiderMode = useStore(hiderMode);
@@ -157,7 +155,6 @@ export const MatchingQuestionComponent = ({
             label={label}
             sub={sub}
             className={className}
-            showDeleteButton={showDeleteButton}
             collapsed={data.collapsed}
             setCollapsed={(collapsed) => {
                 data.collapsed = collapsed; // Doesn't trigger a re-render so no need for questionModified

--- a/src/components/cards/measuring.tsx
+++ b/src/components/cards/measuring.tsx
@@ -1,6 +1,5 @@
 import { LatitudeLongitude } from "../LatLngPicker";
 import { useStore } from "@nanostores/react";
-import { cn } from "@/lib/utils";
 import {
     displayHidingZones,
     drawingQuestionKey,
@@ -10,7 +9,6 @@ import {
     triggerLocalRefresh,
     isLoading,
 } from "@/lib/context";
-import { iconColors } from "@/maps/api";
 import { MENU_ITEM_CLASSNAME, SidebarMenuItem } from "../ui/sidebar-l";
 import { Select } from "../ui/select";
 import { Checkbox } from "../ui/checkbox";
@@ -216,7 +214,7 @@ export const MeasuringQuestionComponent = ({
                     className="grow"
                     type="single"
                     value={data.hiderCloser ? "closer" : "further"}
-                    onValueChange={(value) =>
+                    onValueChange={(value: "closer" | "further") =>
                         questionModified(
                             (data.hiderCloser = value === "closer"),
                         )

--- a/src/components/cards/measuring.tsx
+++ b/src/components/cards/measuring.tsx
@@ -22,6 +22,7 @@ import {
 import { determineMeasuringBoundary } from "@/maps/measuring";
 import { Label } from "@/components/ui/label.tsx";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group.tsx";
+import { cn } from "@/lib/utils";
 
 export const MeasuringQuestionComponent = ({
     data,
@@ -206,7 +207,14 @@ export const MeasuringQuestionComponent = ({
                 disabled={!data.drag || $isLoading}
             />
             <div className="flex gap-2 items-center p-2">
-                <Label className="font-semibold text-lg">Result</Label>
+                <Label
+                    className={cn(
+                        "font-semibold text-lg",
+                        $isLoading && "text-muted-foreground",
+                    )}
+                >
+                    Result
+                </Label>
                 <ToggleGroup
                     className="grow"
                     type="single"

--- a/src/components/cards/measuring.tsx
+++ b/src/components/cards/measuring.tsx
@@ -28,13 +28,11 @@ export const MeasuringQuestionComponent = ({
     questionKey,
     sub,
     className,
-    showDeleteButton = true,
 }: {
     data: MeasuringQuestion;
     questionKey: number;
     sub?: string;
     className?: string;
-    showDeleteButton?: boolean;
 }) => {
     useStore(triggerLocalRefresh);
     const $hiderMode = useStore(hiderMode);
@@ -111,7 +109,6 @@ export const MeasuringQuestionComponent = ({
             label={label}
             sub={sub}
             className={className}
-            showDeleteButton={showDeleteButton}
             collapsed={data.collapsed}
             setCollapsed={(collapsed) => {
                 data.collapsed = collapsed; // Doesn't trigger a re-render so no need for questionModified

--- a/src/components/cards/measuring.tsx
+++ b/src/components/cards/measuring.tsx
@@ -22,6 +22,8 @@ import {
     type MeasuringQuestion,
 } from "@/lib/schema";
 import { determineMeasuringBoundary } from "@/maps/measuring";
+import { Label } from "@/components/ui/label.tsx";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group.tsx";
 
 export const MeasuringQuestionComponent = ({
     data,
@@ -116,6 +118,8 @@ export const MeasuringQuestionComponent = ({
             setCollapsed={(collapsed) => {
                 data.collapsed = collapsed; // Doesn't trigger a re-render so no need for questionModified
             }}
+            locked={!data.drag}
+            setLocked={(locked) => questionModified((data.drag = !locked))}
         >
             <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
                 <Select
@@ -191,43 +195,10 @@ export const MeasuringQuestionComponent = ({
                 />
             </SidebarMenuItem>
             {questionSpecific}
-            <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
-                <label className="text-2xl font-semibold font-poppins">
-                    Hider Closer
-                </label>
-                <Checkbox
-                    disabled={!!$hiderMode || !data.drag || $isLoading}
-                    checked={data.hiderCloser}
-                    onCheckedChange={(checked) =>
-                        questionModified(
-                            (data.hiderCloser = checked as boolean),
-                        )
-                    }
-                />
-            </SidebarMenuItem>
-            <SidebarMenuItem
-                className={cn(
-                    MENU_ITEM_CLASSNAME,
-                    "text-2xl font-semibold font-poppins",
-                )}
-                style={{
-                    backgroundColor: iconColors[data.color],
-                    color: data.color === "gold" ? "black" : undefined,
-                }}
-            >
-                Color (lock{" "}
-                <Checkbox
-                    checked={!data.drag}
-                    disabled={$isLoading}
-                    onCheckedChange={(checked) =>
-                        questionModified((data.drag = !checked as boolean))
-                    }
-                />
-                )
-            </SidebarMenuItem>
             <LatitudeLongitude
                 latitude={data.lat}
                 longitude={data.lng}
+                colorName={data.color}
                 onChange={(lat, lng) => {
                     if (lat !== null) {
                         data.lat = lat;
@@ -239,6 +210,27 @@ export const MeasuringQuestionComponent = ({
                 }}
                 disabled={!data.drag || $isLoading}
             />
+            <div className="flex gap-2 items-center p-2">
+                <Label className="font-semibold text-lg">Result</Label>
+                <ToggleGroup
+                    className="grow"
+                    type="single"
+                    value={data.hiderCloser ? "closer" : "further"}
+                    onValueChange={(value) =>
+                        questionModified(
+                            (data.hiderCloser = value === "closer"),
+                        )
+                    }
+                    disabled={!!$hiderMode || !data.drag || $isLoading}
+                >
+                    <ToggleGroupItem value="further">
+                        Hider Further
+                    </ToggleGroupItem>
+                    <ToggleGroupItem value="closer">
+                        Hider Closer
+                    </ToggleGroupItem>
+                </ToggleGroup>
+            </div>
         </QuestionCard>
     );
 };

--- a/src/components/cards/radius.tsx
+++ b/src/components/cards/radius.tsx
@@ -90,7 +90,14 @@ export const RadiusQuestionComponent = ({
                 disabled={!data.drag || $isLoading}
             />
             <div className="flex gap-2 items-center p-2">
-                <Label className="font-semibold text-lg">Result</Label>
+                <Label
+                    className={cn(
+                        "font-semibold text-lg",
+                        $isLoading && "text-muted-foreground",
+                    )}
+                >
+                    Result
+                </Label>
                 <ToggleGroup
                     className="grow"
                     type="single"

--- a/src/components/cards/radius.tsx
+++ b/src/components/cards/radius.tsx
@@ -9,12 +9,12 @@ import {
     triggerLocalRefresh,
     isLoading,
 } from "@/lib/context";
-import { iconColors } from "@/maps/api";
 import { MENU_ITEM_CLASSNAME, SidebarMenuItem } from "../ui/sidebar-l";
 import { Input } from "../ui/input";
-import { Checkbox } from "../ui/checkbox";
 import { QuestionCard } from "./base";
 import { UnitSelect } from "../UnitSelect";
+import { Label } from "../ui/label";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group.tsx";
 
 export const RadiusQuestionComponent = ({
     data,
@@ -52,6 +52,8 @@ export const RadiusQuestionComponent = ({
             setCollapsed={(collapsed) => {
                 data.collapsed = collapsed; // Doesn't trigger a re-render so no need for questionModified
             }}
+            locked={!data.drag}
+            setLocked={(locked) => questionModified((data.drag = !locked))}
         >
             <SidebarMenuItem>
                 <div className={cn(MENU_ITEM_CLASSNAME, "gap-2 flex flex-row")}>
@@ -75,41 +77,10 @@ export const RadiusQuestionComponent = ({
                     />
                 </div>
             </SidebarMenuItem>
-            <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
-                <label className="text-2xl font-semibold font-poppins">
-                    Within
-                </label>
-                <Checkbox
-                    checked={data.within}
-                    disabled={!!$hiderMode || !data.drag || $isLoading}
-                    onCheckedChange={(checked) =>
-                        questionModified((data.within = checked as boolean))
-                    }
-                />
-            </SidebarMenuItem>
-            <SidebarMenuItem
-                className={cn(
-                    MENU_ITEM_CLASSNAME,
-                    "text-2xl font-semibold font-poppins",
-                )}
-                style={{
-                    backgroundColor: iconColors[data.color],
-                    color: data.color === "gold" ? "black" : undefined,
-                }}
-            >
-                Color (lock{" "}
-                <Checkbox
-                    checked={!data.drag}
-                    disabled={$isLoading}
-                    onCheckedChange={(checked) =>
-                        questionModified((data.drag = !checked as boolean))
-                    }
-                />
-                )
-            </SidebarMenuItem>
             <LatitudeLongitude
                 latitude={data.lat}
                 longitude={data.lng}
+                colorName={data.color}
                 onChange={(lat, lng) => {
                     if (lat !== null) {
                         data.lat = lat;
@@ -121,6 +92,21 @@ export const RadiusQuestionComponent = ({
                 }}
                 disabled={!data.drag || $isLoading}
             />
+            <div className="flex gap-2 items-center p-2">
+                <Label className="font-semibold text-lg">Result</Label>
+                <ToggleGroup
+                    className="grow"
+                    type="single"
+                    value={data.within ? "inside" : "outside"}
+                    onValueChange={(value) =>
+                        questionModified((data.within = value === "inside"))
+                    }
+                    disabled={!!$hiderMode || !data.drag || $isLoading}
+                >
+                    <ToggleGroupItem value="outside">Outside</ToggleGroupItem>
+                    <ToggleGroupItem value="inside">Inside</ToggleGroupItem>
+                </ToggleGroup>
+            </div>
         </QuestionCard>
     );
 };

--- a/src/components/cards/radius.tsx
+++ b/src/components/cards/radius.tsx
@@ -21,13 +21,11 @@ export const RadiusQuestionComponent = ({
     questionKey,
     sub,
     className,
-    showDeleteButton = true,
 }: {
     data: RadiusQuestion;
     questionKey: number;
     sub?: string;
     className?: string;
-    showDeleteButton?: boolean;
 }) => {
     useStore(triggerLocalRefresh);
     const $hiderMode = useStore(hiderMode);
@@ -47,7 +45,6 @@ export const RadiusQuestionComponent = ({
             label={label}
             sub={sub}
             className={className}
-            showDeleteButton={showDeleteButton}
             collapsed={data.collapsed}
             setCollapsed={(collapsed) => {
                 data.collapsed = collapsed; // Doesn't trigger a re-render so no need for questionModified

--- a/src/components/cards/radius.tsx
+++ b/src/components/cards/radius.tsx
@@ -98,7 +98,7 @@ export const RadiusQuestionComponent = ({
                     className="grow"
                     type="single"
                     value={data.within ? "inside" : "outside"}
-                    onValueChange={(value) =>
+                    onValueChange={(value: "inside" | "outside") =>
                         questionModified((data.within = value === "inside"))
                     }
                     disabled={!!$hiderMode || !data.drag || $isLoading}

--- a/src/components/cards/tentacles.tsx
+++ b/src/components/cards/tentacles.tsx
@@ -61,6 +61,8 @@ export const TentacleQuestionComponent = ({
             setCollapsed={(collapsed) => {
                 data.collapsed = collapsed; // Doesn't trigger a re-render so no need for questionModified
             }}
+            locked={!data.drag}
+            setLocked={(locked) => questionModified((data.drag = !locked))}
         >
             <SidebarMenuItem>
                 <div className={cn(MENU_ITEM_CLASSNAME, "gap-2 flex flex-row")}>
@@ -155,29 +157,10 @@ export const TentacleQuestionComponent = ({
                     and use the buttons at the bottom left of the map.
                 </p>
             )}
-            <SidebarMenuItem
-                className={cn(
-                    MENU_ITEM_CLASSNAME,
-                    "text-2xl font-semibold font-poppins",
-                )}
-                style={{
-                    backgroundColor: iconColors[data.color],
-                    color: data.color === "gold" ? "black" : undefined,
-                }}
-            >
-                Color (lock{" "}
-                <Checkbox
-                    checked={!data.drag}
-                    disabled={$isLoading}
-                    onCheckedChange={(checked) =>
-                        questionModified((data.drag = !checked as boolean))
-                    }
-                />
-                )
-            </SidebarMenuItem>
             <LatitudeLongitude
                 latitude={data.lat}
                 longitude={data.lng}
+                colorName={data.color}
                 onChange={(lat, lng) => {
                     if (lat !== null) {
                         data.lat = lat;

--- a/src/components/cards/tentacles.tsx
+++ b/src/components/cards/tentacles.tsx
@@ -10,7 +10,7 @@ import {
     questions,
     triggerLocalRefresh,
 } from "@/lib/context";
-import { findTentacleLocations, iconColors } from "@/maps/api";
+import { findTentacleLocations } from "@/maps/api";
 import { MENU_ITEM_CLASSNAME, SidebarMenuItem } from "../ui/sidebar-l";
 import { Input } from "../ui/input";
 import { Select } from "../ui/select";

--- a/src/components/cards/tentacles.tsx
+++ b/src/components/cards/tentacles.tsx
@@ -31,13 +31,11 @@ export const TentacleQuestionComponent = ({
     questionKey,
     sub,
     className,
-    showDeleteButton = true,
 }: {
     data: TentacleQuestion;
     questionKey: number;
     sub?: string;
     className?: string;
-    showDeleteButton?: boolean;
 }) => {
     const $questions = useStore(questions);
     const $drawingQuestionKey = useStore(drawingQuestionKey);
@@ -56,7 +54,6 @@ export const TentacleQuestionComponent = ({
             label={label}
             sub={sub}
             className={className}
-            showDeleteButton={showDeleteButton}
             collapsed={data.collapsed}
             setCollapsed={(collapsed) => {
                 data.collapsed = collapsed; // Doesn't trigger a re-render so no need for questionModified

--- a/src/components/cards/thermometer.tsx
+++ b/src/components/cards/thermometer.tsx
@@ -8,12 +8,10 @@ import {
     triggerLocalRefresh,
     isLoading,
 } from "@/lib/context";
-import { iconColors } from "@/maps/api";
-import { MENU_ITEM_CLASSNAME, SidebarMenuItem } from "../ui/sidebar-l";
-import { Checkbox } from "../ui/checkbox";
-import { Separator } from "../ui/separator";
 import { QuestionCard } from "./base";
 import type { ThermometerQuestion } from "@/lib/schema";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group.tsx";
+import { Label } from "../ui/label";
 
 export const ThermometerQuestionComponent = ({
     data,
@@ -51,44 +49,14 @@ export const ThermometerQuestionComponent = ({
             setCollapsed={(collapsed) => {
                 data.collapsed = collapsed; // Doesn't trigger a re-render so no need for questionModified
             }}
+            locked={!data.drag}
+            setLocked={(locked) => questionModified((data.drag = !locked))}
         >
-            <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
-                <label className="text-2xl font-semibold font-poppins">
-                    Warmer
-                </label>
-                <Checkbox
-                    disabled={!!$hiderMode || !data.drag || $isLoading}
-                    checked={data.warmer}
-                    onCheckedChange={(checked) =>
-                        questionModified((data.warmer = checked as boolean))
-                    }
-                />
-            </SidebarMenuItem>
-            <SidebarMenuItem
-                className={cn(
-                    MENU_ITEM_CLASSNAME,
-                    "text-xl font-semibold font-poppins",
-                )}
-                style={{
-                    backgroundColor: iconColors[data.colorA],
-                    color: data.colorA === "gold" ? "black" : undefined,
-                }}
-            >
-                Color start (lock{" "}
-                <Checkbox
-                    checked={!data.drag}
-                    disabled={$isLoading}
-                    onCheckedChange={(checked) =>
-                        questionModified((data.drag = !checked as boolean))
-                    }
-                />
-                )
-            </SidebarMenuItem>
             <LatitudeLongitude
                 latitude={data.latA}
                 longitude={data.lngA}
-                latLabel="Latitude Start"
-                lngLabel="Longitude Start"
+                label="Start"
+                colorName={data.colorA}
                 onChange={(lat, lng) => {
                     if (lat !== null) {
                         data.latA = lat;
@@ -100,24 +68,11 @@ export const ThermometerQuestionComponent = ({
                 }}
                 disabled={!data.drag || $isLoading}
             />
-            <Separator className="my-2" />
-            <SidebarMenuItem
-                className={cn(
-                    MENU_ITEM_CLASSNAME,
-                    "text-xl font-semibold font-poppins",
-                )}
-                style={{
-                    backgroundColor: iconColors[data.colorB],
-                    color: data.colorB === "gold" ? "black" : undefined,
-                }}
-            >
-                Color end
-            </SidebarMenuItem>
             <LatitudeLongitude
                 latitude={data.latB}
                 longitude={data.lngB}
-                latLabel="Latitude End"
-                lngLabel="Longitude End"
+                label="End"
+                colorName={data.colorB}
                 onChange={(lat, lng) => {
                     if (lat !== null) {
                         data.latB = lat;
@@ -129,6 +84,23 @@ export const ThermometerQuestionComponent = ({
                 }}
                 disabled={!data.drag || $isLoading}
             />
+            <div className="flex gap-2 items-center p-2">
+                <Label className="font-semibold text-lg">Result</Label>
+                <ToggleGroup
+                    className="grow"
+                    type="single"
+                    value={data.warmer ? "warmer" : "colder"}
+                    onValueChange={(value) =>
+                        questionModified((data.warmer = value === "warmer"))
+                    }
+                    disabled={!!$hiderMode || !data.drag || $isLoading}
+                >
+                    <ToggleGroupItem color="red" value="colder">
+                        Colder
+                    </ToggleGroupItem>
+                    <ToggleGroupItem value="warmer">Warmer</ToggleGroupItem>
+                </ToggleGroup>
+            </div>
         </QuestionCard>
     );
 };

--- a/src/components/cards/thermometer.tsx
+++ b/src/components/cards/thermometer.tsx
@@ -17,13 +17,11 @@ export const ThermometerQuestionComponent = ({
     questionKey,
     sub,
     className,
-    showDeleteButton = true,
 }: {
     data: ThermometerQuestion;
     questionKey: number;
     sub?: string;
     className?: string;
-    showDeleteButton?: boolean;
 }) => {
     useStore(triggerLocalRefresh);
     const $hiderMode = useStore(hiderMode);
@@ -43,7 +41,6 @@ export const ThermometerQuestionComponent = ({
             label={label}
             sub={sub}
             className={className}
-            showDeleteButton={showDeleteButton}
             collapsed={data.collapsed}
             setCollapsed={(collapsed) => {
                 data.collapsed = collapsed; // Doesn't trigger a re-render so no need for questionModified

--- a/src/components/cards/thermometer.tsx
+++ b/src/components/cards/thermometer.tsx
@@ -1,6 +1,5 @@
 import { LatitudeLongitude } from "../LatLngPicker";
 import { useStore } from "@nanostores/react";
-import { cn } from "@/lib/utils";
 import {
     hiderMode,
     questionModified,
@@ -90,7 +89,7 @@ export const ThermometerQuestionComponent = ({
                     className="grow"
                     type="single"
                     value={data.warmer ? "warmer" : "colder"}
-                    onValueChange={(value) =>
+                    onValueChange={(value: "warmer" | "colder") =>
                         questionModified((data.warmer = value === "warmer"))
                     }
                     disabled={!!$hiderMode || !data.drag || $isLoading}

--- a/src/components/cards/thermometer.tsx
+++ b/src/components/cards/thermometer.tsx
@@ -11,6 +11,7 @@ import { QuestionCard } from "./base";
 import type { ThermometerQuestion } from "@/lib/schema";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group.tsx";
 import { Label } from "../ui/label";
+import { cn } from "@/lib/utils";
 
 export const ThermometerQuestionComponent = ({
     data,
@@ -81,7 +82,14 @@ export const ThermometerQuestionComponent = ({
                 disabled={!data.drag || $isLoading}
             />
             <div className="flex gap-2 items-center p-2">
-                <Label className="font-semibold text-lg">Result</Label>
+                <Label
+                    className={cn(
+                        "font-semibold text-lg",
+                        $isLoading && "text-muted-foreground",
+                    )}
+                >
+                    Result
+                </Label>
                 <ToggleGroup
                     className="grow"
                     type="single"

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
+import { type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants>
+>({
+  size: "default",
+  variant: "default",
+})
+
+const ToggleGroup = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, children, ...props }, ref) => (
+  <ToggleGroupPrimitive.Root
+    ref={ref}
+    className={cn("flex items-center justify-center gap-1", className)}
+    {...props}
+  >
+    <ToggleGroupContext.Provider value={{ variant, size }}>
+      {children}
+    </ToggleGroupContext.Provider>
+  </ToggleGroupPrimitive.Root>
+))
+
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName
+
+const ToggleGroupItem = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+    VariantProps<typeof toggleVariants>
+>(({ className, children, variant, size, ...props }, ref) => {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+})
+
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName
+
+export { ToggleGroup, ToggleGroupItem }

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,59 +1,59 @@
-import * as React from "react"
-import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
-import { type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import { type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
-import { toggleVariants } from "@/components/ui/toggle"
+import { cn } from "@/lib/utils";
+import { toggleVariants } from "@/components/ui/toggle";
 
 const ToggleGroupContext = React.createContext<
-  VariantProps<typeof toggleVariants>
+    VariantProps<typeof toggleVariants>
 >({
-  size: "default",
-  variant: "default",
-})
+    size: "default",
+    variant: "default",
+});
 
 const ToggleGroup = React.forwardRef<
-  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
-    VariantProps<typeof toggleVariants>
+    React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+    React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
+        VariantProps<typeof toggleVariants>
 >(({ className, variant, size, children, ...props }, ref) => (
-  <ToggleGroupPrimitive.Root
-    ref={ref}
-    className={cn("flex items-center justify-center gap-1", className)}
-    {...props}
-  >
-    <ToggleGroupContext.Provider value={{ variant, size }}>
-      {children}
-    </ToggleGroupContext.Provider>
-  </ToggleGroupPrimitive.Root>
-))
+    <ToggleGroupPrimitive.Root
+        ref={ref}
+        className={cn("flex items-center justify-center gap-1", className)}
+        {...props}
+    >
+        <ToggleGroupContext.Provider value={{ variant, size }}>
+            {children}
+        </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+));
 
-ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
 
 const ToggleGroupItem = React.forwardRef<
-  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
-    VariantProps<typeof toggleVariants>
+    React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+    React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+        VariantProps<typeof toggleVariants>
 >(({ className, children, variant, size, ...props }, ref) => {
-  const context = React.useContext(ToggleGroupContext)
+    const context = React.useContext(ToggleGroupContext);
 
-  return (
-    <ToggleGroupPrimitive.Item
-      ref={ref}
-      className={cn(
-        toggleVariants({
-          variant: context.variant || variant,
-          size: context.size || size,
-        }),
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </ToggleGroupPrimitive.Item>
-  )
-})
+    return (
+        <ToggleGroupPrimitive.Item
+            ref={ref}
+            className={cn(
+                toggleVariants({
+                    variant: context.variant || variant,
+                    size: context.size || size,
+                }),
+                className,
+            )}
+            {...props}
+        >
+            {children}
+        </ToggleGroupPrimitive.Item>
+    );
+});
 
-ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
 
-export { ToggleGroup, ToggleGroupItem }
+export { ToggleGroup, ToggleGroupItem };

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import * as React from "react"
+import * as TogglePrimitive from "@radix-ui/react-toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-10 px-3 min-w-10",
+        sm: "h-9 px-2.5 min-w-9",
+        lg: "h-11 px-5 min-w-11",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+const Toggle = React.forwardRef<
+  React.ElementRef<typeof TogglePrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+  <TogglePrimitive.Root
+    ref={ref}
+    className={cn(toggleVariants({ variant, size, className }))}
+    {...props}
+  />
+))
+
+Toggle.displayName = TogglePrimitive.Root.displayName
+
+export { Toggle, toggleVariants }

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,45 +1,45 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as TogglePrimitive from "@radix-ui/react-toggle"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2",
-  {
-    variants: {
-      variant: {
-        default: "bg-transparent",
-        outline:
-          "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
-      },
-      size: {
-        default: "h-10 px-3 min-w-10",
-        sm: "h-9 px-2.5 min-w-9",
-        lg: "h-11 px-5 min-w-11",
-      },
+    "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2",
+    {
+        variants: {
+            variant: {
+                default: "bg-transparent",
+                outline:
+                    "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+            },
+            size: {
+                default: "h-10 px-3 min-w-10",
+                sm: "h-9 px-2.5 min-w-9",
+                lg: "h-11 px-5 min-w-11",
+            },
+        },
+        defaultVariants: {
+            variant: "default",
+            size: "default",
+        },
     },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+);
 
 const Toggle = React.forwardRef<
-  React.ElementRef<typeof TogglePrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
-    VariantProps<typeof toggleVariants>
+    React.ElementRef<typeof TogglePrimitive.Root>,
+    React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+        VariantProps<typeof toggleVariants>
 >(({ className, variant, size, ...props }, ref) => (
-  <TogglePrimitive.Root
-    ref={ref}
-    className={cn(toggleVariants({ variant, size, className }))}
-    {...props}
-  />
-))
+    <TogglePrimitive.Root
+        ref={ref}
+        className={cn(toggleVariants({ variant, size, className }))}
+        {...props}
+    />
+));
 
-Toggle.displayName = TogglePrimitive.Root.displayName
+Toggle.displayName = TogglePrimitive.Root.displayName;
 
-export { Toggle, toggleVariants }
+export { Toggle, toggleVariants };

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -153,7 +153,7 @@ export const hidingZone = computed(
         additionalMapGeoLocations,
         disabledStations,
         hidingRadius,
-        displayHidingZonesOptions
+        displayHidingZonesOptions,
     ],
     (q, geo, loc, altLoc, disabledStations, radius, zoneOptions) => {
         if (geo !== null) {


### PR DESCRIPTION
This is a PR that reworks the design of the Lat/Long picker, and with that, the entire questions UI.

It removes the Lat/Long inputs and moves them into a dialog, putting focus on the current location/paste location input methods.
The thought process behind this is that most people that would input coordinates manually will just use the paste button instead. By moving those inputs into a dialog, we can clean up a lot of space that was previously wasted. In the future, this dialog could also contain an input for geocoded search, so users are able to input Landmark locations directly.
I've also moved the color indicator for the location to be directly behind the picker, which saves more space and seems more intuitive too.

This lead to some other UI changes: The lock/unlock button couldn't be inside the color indicator anymore, so I decided to move it to the bottom, along with the share and delete buttons which were previously next to the question title (I'm not 100% sure about this change).

Another change I made is moving the result to the bottom of the question. Since the other data would be input first, it seemed more sensible to do it this way.

Here's a screenshot of all the changes together:
<img width="258" alt="Screenshot 2025-06-03 at 19 41 32" src="https://github.com/user-attachments/assets/a1006a09-83bd-46b0-ad90-e9cbbf54b8b5" />

This is a pretty big overhaul, so I wanted to make a draft PR and ask for feedback first before finishing up some of the changes. There's still some styling that can be improved, and I think there's some linting errors as well. Let me know what you think!