### PR TITLE
Debounce a variety of inputs

### DIFF
--- a/src/components/ZoneSidebar.tsx
+++ b/src/components/ZoneSidebar.tsx
@@ -478,7 +478,7 @@ export const ZoneSidebar = () => {
                                     <Input
                                         type="number"
                                         className="rounded-md p-2 w-16"
-                                        defaultValue={$hidingRadius}
+                                        value={$hidingRadius}
                                         onChange={(e) => {
                                             hidingRadius.set(
                                                 parseFloat(e.target.value),

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,22 +1,60 @@
 import * as React from "react";
 
+import { useDebounce } from "@/hooks/useDebounce";
 import { cn } from "@/lib/utils";
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-    ({ className, type, ...props }, ref) => {
+const RawInput = React.forwardRef<
+    HTMLInputElement,
+    React.ComponentProps<"input">
+>(({ className, type, ...props }, ref) => {
+    return (
+        <input
+            type={type}
+            className={cn(
+                "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+                className,
+            )}
+            ref={ref}
+            {...props}
+        />
+    );
+});
+RawInput.displayName = "RawInput";
+
+type DebouncedInputProps = React.ComponentProps<"input"> & {
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    debounce?: number;
+};
+
+const Input = React.forwardRef<HTMLInputElement, DebouncedInputProps>(
+    ({ onChange, debounce = 500, value, ...props }, ref) => {
+        const [internalValue, setInternalValue] = React.useState(value ?? "");
+        const debouncedValue = useDebounce(internalValue, debounce);
+
+        React.useEffect(() => {
+            if (debouncedValue !== value && onChange) {
+                const event = {
+                    ...({} as React.ChangeEvent<HTMLInputElement>),
+                    target: { value: debouncedValue },
+                };
+                onChange(event as React.ChangeEvent<HTMLInputElement>);
+            }
+        }, [debouncedValue]);
+
+        React.useEffect(() => {
+            setInternalValue(value ?? "");
+        }, [value]);
+
         return (
-            <input
-                type={type}
-                className={cn(
-                    "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-                    className,
-                )}
-                ref={ref}
+            <RawInput
                 {...props}
+                ref={ref}
+                value={internalValue}
+                onChange={(e) => setInternalValue(e.target.value)}
             />
         );
     },
 );
 Input.displayName = "Input";
 
-export { Input };
+export { Input, RawInput };

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -19,6 +19,7 @@ import {
     PopoverTrigger,
 } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
+import { useDebounce } from "@/hooks/useDebounce";
 import { cn } from "@/lib/utils";
 
 /**
@@ -109,6 +110,12 @@ interface MultiSelectProps
      * Optional, can be used to add custom styles.
      */
     className?: string;
+
+    /**
+     * Debounce time in milliseconds for onValueChange callback.
+     * Optional, defaults to 500ms.
+     */
+    debounce?: number;
 }
 
 export const MultiSelect = React.forwardRef<
@@ -126,15 +133,20 @@ export const MultiSelect = React.forwardRef<
             maxCount = 3,
             modalPopover = false,
             className,
+            debounce = 500,
             ...props
         },
         ref,
     ) => {
-        const [selectedValues, setSelectedValues] =
-            React.useState<string[]>(defaultValue);
+        const [selectedValues, setSelectedValues] = React.useState<string[]>(defaultValue);
         const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const [isAnimating, setIsAnimating] = React.useState(false);
+
+        const debouncedSelectedValues = useDebounce(selectedValues, debounce);
+        React.useEffect(() => {
+            onValueChange(debouncedSelectedValues);
+        }, [debouncedSelectedValues]);
 
         const handleInputKeyDown = (
             event: React.KeyboardEvent<HTMLInputElement>,
@@ -148,7 +160,6 @@ export const MultiSelect = React.forwardRef<
                 const newSelectedValues = [...selectedValues];
                 newSelectedValues.pop();
                 setSelectedValues(newSelectedValues);
-                onValueChange(newSelectedValues);
             }
         };
 
@@ -157,12 +168,10 @@ export const MultiSelect = React.forwardRef<
                 ? selectedValues.filter((value) => value !== option)
                 : [...selectedValues, option];
             setSelectedValues(newSelectedValues);
-            onValueChange(newSelectedValues);
         };
 
         const handleClear = () => {
             setSelectedValues([]);
-            onValueChange([]);
         };
 
         const handleTogglePopover = () => {
@@ -172,7 +181,6 @@ export const MultiSelect = React.forwardRef<
         const clearExtraOptions = () => {
             const newSelectedValues = selectedValues.slice(0, maxCount);
             setSelectedValues(newSelectedValues);
-            onValueChange(newSelectedValues);
         };
 
         const toggleAll = () => {
@@ -181,7 +189,6 @@ export const MultiSelect = React.forwardRef<
             } else {
                 const allValues = options.map((option) => option.value);
                 setSelectedValues(allValues);
-                onValueChange(allValues);
             }
         };
 


### PR DESCRIPTION
This PR debounces inputs and multiselects such that the user can fully type their metrics without the map reloading and their cursor getting kicked out of the input. If there are any other forms of input that should also be debounced, please let me know.

@zusorio, can you review this before I merge it?

Closes #129 