### PR TITLE
feat: fallback to clipboard on native share fail

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,251 +1,190 @@
 {
-  "files": [
-    "README.md"
-  ],
-  "imageSize": 100,
-  "commit": false,
-  "commitType": "docs",
-  "commitConvention": "angular",
-  "contributors": [
-    {
-      "login": "taibeled",
-      "name": "taibeled",
-      "avatar_url": "https://avatars.githubusercontent.com/u/179261820?v=4",
-      "profile": "https://github.com/taibeled",
-      "contributions": [
-        "bug",
-        "code",
-        "design",
-        "doc"
-      ]
-    },
-    {
-      "login": "vdumestre",
-      "name": "vdumestre",
-      "avatar_url": "https://avatars.githubusercontent.com/u/33914769?v=4",
-      "profile": "https://github.com/vdumestre",
-      "contributions": [
-        "ideas"
-      ]
-    },
-    {
-      "login": "MrYawnie",
-      "name": "Jani Andsten",
-      "avatar_url": "https://avatars.githubusercontent.com/u/14262612?v=4",
-      "profile": "https://github.com/MrYawnie",
-      "contributions": [
-        "code"
-      ]
-    },
-    {
-      "login": "BoringCode",
-      "name": "ʙʀᴀᴅʟᴇʏ ʀᴏsᴇɴғᴇʟᴅ",
-      "avatar_url": "https://avatars.githubusercontent.com/u/938452?v=4",
-      "profile": "https://bradleyrosenfeld.com/",
-      "contributions": [
-        "code",
-        "bug"
-      ]
-    },
-    {
-      "login": "abrahamguo",
-      "name": "Abraham Guo",
-      "avatar_url": "https://avatars.githubusercontent.com/u/7842684?v=4",
-      "profile": "https://github.com/abrahamguo",
-      "contributions": [
-        "code"
-      ]
-    },
-    {
-      "login": "zusorio",
-      "name": "Tobias Messner",
-      "avatar_url": "https://avatars.githubusercontent.com/u/23165606?v=4",
-      "profile": "https://zusor.io/",
-      "contributions": [
-        "code"
-      ]
-    },
-    {
-      "login": "UnknownSilicon",
-      "name": "Eris",
-      "avatar_url": "https://avatars.githubusercontent.com/u/14339279?v=4",
-      "profile": "https://github.com/UnknownSilicon",
-      "contributions": [
-        "code"
-      ]
-    },
-    {
-      "login": "khiral",
-      "name": "khiral",
-      "avatar_url": "https://avatars.githubusercontent.com/u/23667350?v=4",
-      "profile": "https://github.com/khiral",
-      "contributions": [
-        "code"
-      ]
-    },
-    {
-      "login": "hanneshier",
-      "name": "hanneshier",
-      "avatar_url": "https://avatars.githubusercontent.com/u/11063798?v=4",
-      "profile": "https://github.com/hanneshier",
-      "contributions": [
-        "ideas"
-      ]
-    },
-    {
-      "login": "blahajjessie",
-      "name": "blahajjessie",
-      "avatar_url": "https://avatars.githubusercontent.com/u/78718906?v=4",
-      "profile": "https://github.com/blahajjessie",
-      "contributions": [
-        "ideas"
-      ]
-    },
-    {
-      "login": "Blaa00",
-      "name": "Bla0",
-      "avatar_url": "https://avatars.githubusercontent.com/u/88278955?v=4",
-      "profile": "https://bagottgames.uk/",
-      "contributions": [
-        "ideas"
-      ]
-    },
-    {
-      "login": "leoherzog",
-      "name": "Leo",
-      "avatar_url": "https://avatars.githubusercontent.com/u/5376265?v=4",
-      "profile": "https://herzog.tech/",
-      "contributions": [
-        "ideas"
-      ]
-    },
-    {
-      "login": "Acclamator",
-      "name": "Acclamator",
-      "avatar_url": "https://avatars.githubusercontent.com/u/4201849?v=4",
-      "profile": "https://github.com/Acclamator",
-      "contributions": [
-        "ideas"
-      ]
-    },
-    {
-      "login": "selacey42",
-      "name": "selacey42",
-      "avatar_url": "https://avatars.githubusercontent.com/u/200851729?v=4",
-      "profile": "https://github.com/selacey42",
-      "contributions": [
-        "ideas",
-        "bug"
-      ]
-    },
-    {
-      "login": "asemaca",
-      "name": "asemaca",
-      "avatar_url": "https://avatars.githubusercontent.com/u/64056714?v=4",
-      "profile": "https://github.com/asemaca",
-      "contributions": [
-        "ideas",
-        "bug"
-      ]
-    },
-    {
-      "login": "Akiva-Cohen",
-      "name": "Akiva Cohen",
-      "avatar_url": "https://avatars.githubusercontent.com/u/150308530?v=4",
-      "profile": "https://github.com/Akiva-Cohen",
-      "contributions": [
-        "ideas",
-        "bug"
-      ]
-    },
-    {
-      "login": "ChrisHartman",
-      "name": "Christopher Robert Hartman",
-      "avatar_url": "https://avatars.githubusercontent.com/u/9095854?v=4",
-      "profile": "https://github.com/ChrisHartman",
-      "contributions": [
-        "ideas"
-      ]
-    },
-    {
-      "login": "miniBill",
-      "name": "Leonardo Taglialegne",
-      "avatar_url": "https://avatars.githubusercontent.com/u/191825?v=4",
-      "profile": "https://github.com/miniBill",
-      "contributions": [
-        "ideas"
-      ]
-    },
-    {
-      "login": "JackSouster",
-      "name": "JackSouster",
-      "avatar_url": "https://avatars.githubusercontent.com/u/96268675?v=4",
-      "profile": "https://github.com/JackSouster",
-      "contributions": [
-        "bug"
-      ]
-    },
-    {
-      "login": "fkloft",
-      "name": "fkloft",
-      "avatar_url": "https://avatars.githubusercontent.com/u/2741656?v=4",
-      "profile": "https://github.com/fkloft",
-      "contributions": [
-        "ideas"
-      ]
-    },
-    {
-      "login": "InvestigateXM",
-      "name": "InvestigateXM",
-      "avatar_url": "https://avatars.githubusercontent.com/u/52758500?v=4",
-      "profile": "https://github.com/InvestigateXM",
-      "contributions": [
-        "ideas"
-      ]
-    },
-    {
-      "login": "Hawkguye",
-      "name": "Hawkguye",
-      "avatar_url": "https://avatars.githubusercontent.com/u/121480806?v=4",
-      "profile": "https://github.com/Hawkguye",
-      "contributions": [
-        "data"
-      ]
-    },
-    {
-      "login": "jlewis1778",
-      "name": "jlewis1778",
-      "avatar_url": "https://avatars.githubusercontent.com/u/22303191?v=4",
-      "profile": "https://github.com/jlewis1778",
-      "contributions": [
-        "code",
-        "bug"
-      ]
-    },
-    {
-      "login": "Bert-Moors",
-      "name": "Bert-Moors",
-      "avatar_url": "https://avatars.githubusercontent.com/u/89836592?v=4",
-      "profile": "https://github.com/Bert-Moors",
-      "contributions": [
-        "code",
-        "bug"
-      ]
-    },
-    {
-      "login": "azyritedev",
-      "name": "azyrite",
-      "avatar_url": "https://avatars.githubusercontent.com/u/206858676?v=4",
-      "profile": "https://github.com/azyritedev",
-      "contributions": [
-        "code"
-      ]
-    }
-  ],
-  "contributorsPerLine": 7,
-  "skipCi": true,
-  "repoType": "github",
-  "repoHost": "https://github.com",
-  "projectName": "JetLagHideAndSeek",
-  "projectOwner": "taibeled"
+    "files": ["README.md"],
+    "imageSize": 100,
+    "commit": false,
+    "commitType": "docs",
+    "commitConvention": "angular",
+    "contributors": [
+        {
+            "login": "taibeled",
+            "name": "taibeled",
+            "avatar_url": "https://avatars.githubusercontent.com/u/179261820?v=4",
+            "profile": "https://github.com/taibeled",
+            "contributions": ["bug", "code", "design", "doc"]
+        },
+        {
+            "login": "vdumestre",
+            "name": "vdumestre",
+            "avatar_url": "https://avatars.githubusercontent.com/u/33914769?v=4",
+            "profile": "https://github.com/vdumestre",
+            "contributions": ["ideas"]
+        },
+        {
+            "login": "MrYawnie",
+            "name": "Jani Andsten",
+            "avatar_url": "https://avatars.githubusercontent.com/u/14262612?v=4",
+            "profile": "https://github.com/MrYawnie",
+            "contributions": ["code"]
+        },
+        {
+            "login": "BoringCode",
+            "name": "ʙʀᴀᴅʟᴇʏ ʀᴏsᴇɴғᴇʟᴅ",
+            "avatar_url": "https://avatars.githubusercontent.com/u/938452?v=4",
+            "profile": "https://bradleyrosenfeld.com/",
+            "contributions": ["code", "bug"]
+        },
+        {
+            "login": "abrahamguo",
+            "name": "Abraham Guo",
+            "avatar_url": "https://avatars.githubusercontent.com/u/7842684?v=4",
+            "profile": "https://github.com/abrahamguo",
+            "contributions": ["code"]
+        },
+        {
+            "login": "zusorio",
+            "name": "Tobias Messner",
+            "avatar_url": "https://avatars.githubusercontent.com/u/23165606?v=4",
+            "profile": "https://zusor.io/",
+            "contributions": ["code"]
+        },
+        {
+            "login": "UnknownSilicon",
+            "name": "Eris",
+            "avatar_url": "https://avatars.githubusercontent.com/u/14339279?v=4",
+            "profile": "https://github.com/UnknownSilicon",
+            "contributions": ["code"]
+        },
+        {
+            "login": "khiral",
+            "name": "khiral",
+            "avatar_url": "https://avatars.githubusercontent.com/u/23667350?v=4",
+            "profile": "https://github.com/khiral",
+            "contributions": ["code"]
+        },
+        {
+            "login": "hanneshier",
+            "name": "hanneshier",
+            "avatar_url": "https://avatars.githubusercontent.com/u/11063798?v=4",
+            "profile": "https://github.com/hanneshier",
+            "contributions": ["ideas"]
+        },
+        {
+            "login": "blahajjessie",
+            "name": "blahajjessie",
+            "avatar_url": "https://avatars.githubusercontent.com/u/78718906?v=4",
+            "profile": "https://github.com/blahajjessie",
+            "contributions": ["ideas"]
+        },
+        {
+            "login": "Blaa00",
+            "name": "Bla0",
+            "avatar_url": "https://avatars.githubusercontent.com/u/88278955?v=4",
+            "profile": "https://bagottgames.uk/",
+            "contributions": ["ideas"]
+        },
+        {
+            "login": "leoherzog",
+            "name": "Leo",
+            "avatar_url": "https://avatars.githubusercontent.com/u/5376265?v=4",
+            "profile": "https://herzog.tech/",
+            "contributions": ["ideas"]
+        },
+        {
+            "login": "Acclamator",
+            "name": "Acclamator",
+            "avatar_url": "https://avatars.githubusercontent.com/u/4201849?v=4",
+            "profile": "https://github.com/Acclamator",
+            "contributions": ["ideas"]
+        },
+        {
+            "login": "selacey42",
+            "name": "selacey42",
+            "avatar_url": "https://avatars.githubusercontent.com/u/200851729?v=4",
+            "profile": "https://github.com/selacey42",
+            "contributions": ["ideas", "bug"]
+        },
+        {
+            "login": "asemaca",
+            "name": "asemaca",
+            "avatar_url": "https://avatars.githubusercontent.com/u/64056714?v=4",
+            "profile": "https://github.com/asemaca",
+            "contributions": ["ideas", "bug"]
+        },
+        {
+            "login": "Akiva-Cohen",
+            "name": "Akiva Cohen",
+            "avatar_url": "https://avatars.githubusercontent.com/u/150308530?v=4",
+            "profile": "https://github.com/Akiva-Cohen",
+            "contributions": ["ideas", "bug"]
+        },
+        {
+            "login": "ChrisHartman",
+            "name": "Christopher Robert Hartman",
+            "avatar_url": "https://avatars.githubusercontent.com/u/9095854?v=4",
+            "profile": "https://github.com/ChrisHartman",
+            "contributions": ["ideas"]
+        },
+        {
+            "login": "miniBill",
+            "name": "Leonardo Taglialegne",
+            "avatar_url": "https://avatars.githubusercontent.com/u/191825?v=4",
+            "profile": "https://github.com/miniBill",
+            "contributions": ["ideas"]
+        },
+        {
+            "login": "JackSouster",
+            "name": "JackSouster",
+            "avatar_url": "https://avatars.githubusercontent.com/u/96268675?v=4",
+            "profile": "https://github.com/JackSouster",
+            "contributions": ["bug"]
+        },
+        {
+            "login": "fkloft",
+            "name": "fkloft",
+            "avatar_url": "https://avatars.githubusercontent.com/u/2741656?v=4",
+            "profile": "https://github.com/fkloft",
+            "contributions": ["ideas"]
+        },
+        {
+            "login": "InvestigateXM",
+            "name": "InvestigateXM",
+            "avatar_url": "https://avatars.githubusercontent.com/u/52758500?v=4",
+            "profile": "https://github.com/InvestigateXM",
+            "contributions": ["ideas"]
+        },
+        {
+            "login": "Hawkguye",
+            "name": "Hawkguye",
+            "avatar_url": "https://avatars.githubusercontent.com/u/121480806?v=4",
+            "profile": "https://github.com/Hawkguye",
+            "contributions": ["data"]
+        },
+        {
+            "login": "jlewis1778",
+            "name": "jlewis1778",
+            "avatar_url": "https://avatars.githubusercontent.com/u/22303191?v=4",
+            "profile": "https://github.com/jlewis1778",
+            "contributions": ["code", "bug"]
+        },
+        {
+            "login": "Bert-Moors",
+            "name": "Bert-Moors",
+            "avatar_url": "https://avatars.githubusercontent.com/u/89836592?v=4",
+            "profile": "https://github.com/Bert-Moors",
+            "contributions": ["code", "bug"]
+        },
+        {
+            "login": "azyritedev",
+            "name": "azyrite",
+            "avatar_url": "https://avatars.githubusercontent.com/u/206858676?v=4",
+            "profile": "https://github.com/azyritedev",
+            "contributions": ["code"]
+        }
+    ],
+    "contributorsPerLine": 7,
+    "skipCi": true,
+    "repoType": "github",
+    "repoHost": "https://github.com",
+    "projectName": "JetLagHideAndSeek",
+    "projectOwner": "taibeled"
 }

--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -40,6 +40,7 @@ import {
     compress,
     decompress,
     fetchFromPastebin,
+    shareOrFallback,
     uploadToPastebin,
 } from "@/lib/utils";
 import { questionsSchema } from "@/maps/schema";
@@ -246,28 +247,24 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                     }
 
                     // Show platform native share sheet if possible
-                    if (navigator.share) {
-                        navigator
-                            .share({
-                                title: document.title,
-                                url: shareUrl,
-                            })
-                            .catch(() =>
-                                toast.error(
-                                    "Failed to share via OS. If data is very large, ensure Pastebin settings are correct.",
-                                ),
+                    await shareOrFallback(shareUrl).then((result) => {
+                        console.log(`result ${result}`);
+                        if (result === false) {
+                            return toast.error(
+                                `Clipboard not supported. Try manually copying/pasting: ${shareUrl}`,
+                                { className: "p-0 w-[1000px]" },
                             );
-                    } else if (!navigator || !navigator.clipboard) {
-                        return toast.error(
-                            `Clipboard not supported. Try manually copying/pasting: ${shareUrl}`,
-                            { className: "p-0 w-[1000px]" },
-                        );
-                    } else {
-                        navigator.clipboard.writeText(shareUrl);
-                        toast.success("Hiding zone URL copied to clipboard", {
-                            autoClose: 2000,
-                        });
-                    }
+                        }
+
+                        if (result === "clipboard") {
+                            toast.success(
+                                "Hiding zone URL copied to clipboard",
+                                {
+                                    autoClose: 2000,
+                                },
+                            );
+                        }
+                    });
                 }}
                 data-tutorial-id="share-questions-button"
             >

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -164,7 +164,16 @@ export const hidingZone = computed(
         hidingRadiusUnits,
         displayHidingZonesOptions,
     ],
-    (q, geo, loc, altLoc, disabledStations, radius, hidingRadiusUnits, zoneOptions) => {
+    (
+        q,
+        geo,
+        loc,
+        altLoc,
+        disabledStations,
+        radius,
+        hidingRadiusUnits,
+        zoneOptions,
+    ) => {
         if (geo !== null) {
             return {
                 ...geo,

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -161,15 +161,17 @@ export const hidingZone = computed(
         additionalMapGeoLocations,
         disabledStations,
         hidingRadius,
+        hidingRadiusUnits,
         displayHidingZonesOptions,
     ],
-    (q, geo, loc, altLoc, disabledStations, radius, zoneOptions) => {
+    (q, geo, loc, altLoc, disabledStations, radius, hidingRadiusUnits, zoneOptions) => {
         if (geo !== null) {
             return {
                 ...geo,
                 questions: q,
                 disabledStations: disabledStations,
                 hidingRadius: radius,
+                hidingRadiusUnits,
                 zoneOptions: zoneOptions,
             };
         } else {
@@ -180,6 +182,7 @@ export const hidingZone = computed(
                 ...$loc,
                 disabledStations: disabledStations,
                 hidingRadius: radius,
+                hidingRadiusUnits,
                 alternateLocations: structuredClone(altLoc),
                 zoneOptions: zoneOptions,
             };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -94,3 +94,34 @@ export async function fetchFromPastebin(pasteId: string): Promise<string> {
 
     return response.text();
 }
+
+/**
+ * Open native share sheet or fallback to sending to clipboard
+ * @param url URL to share
+ * @param forceClipboard Whether to force usage of the clipboard (instead of share sheet)
+ * @returns `true` for native success, `false` for both native and fallback failure and `"clipboard"` for clipboard success
+ */
+export async function shareOrFallback(
+    url: string,
+    forceClipboard = false,
+): Promise<boolean | "clipboard"> {
+    if (forceClipboard) {
+        if (!navigator || !navigator.clipboard) {
+            // Clipboard not supported
+            return false;
+        }
+
+        navigator.clipboard.writeText(url);
+        return "clipboard";
+    }
+
+    if (!navigator.share) return shareOrFallback(url, true); // Fallback to clipboard
+
+    return await navigator
+        .share({ url })
+        .then(() => true)
+        .catch(() => {
+            // Try again with clipboard
+            return shareOrFallback(url, true);
+        });
+}

--- a/src/maps/schema.ts
+++ b/src/maps/schema.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
-import { ICON_COLORS } from "./api/constants";
 import { defaultUnit } from "@/lib/context";
+
+import { ICON_COLORS } from "./api/constants";
 
 export const NO_GROUP = "NO_GROUP";
 
@@ -88,7 +89,7 @@ const getDefaultUnit = () => {
     } catch {
         return "miles";
     }
-}
+};
 
 const radiusQuestionSchema = ordinaryBaseQuestionSchema.extend({
     radius: z.number().min(0, "You cannot have a negative radius").default(50),


### PR DESCRIPTION
Partially addresses #141 by extracting `navigator.share` calls into utility function which falls back to using the clipboard if the native share sheet fails to work.

Also persists `hidingRadiusUnits` from previous PR, see `context.ts` changes.