### PR TITLE
Add 'Display Name' to questions

### DIFF
--- a/src/components/cards/base.tsx
+++ b/src/components/cards/base.tsx
@@ -38,6 +38,7 @@ export const QuestionCard = ({
     questionKey,
     className,
     label,
+    friendlyName,
     sub,
     collapsed,
     locked,
@@ -48,6 +49,7 @@ export const QuestionCard = ({
     questionKey: number;
     className?: string;
     label?: string;
+    friendlyName?: string;
     sub?: string;
     collapsed?: boolean;
     locked?: boolean;
@@ -66,6 +68,11 @@ export const QuestionCard = ({
         setIsCollapsed((prevState) => !prevState);
     };
 
+    let displayLabel = label;
+    if (friendlyName != null && friendlyName !== "") {
+        displayLabel = friendlyName;
+    }
+
     return (
         <>
             <SidebarGroup className={className}>
@@ -83,7 +90,7 @@ export const QuestionCard = ({
                         className="ml-8 mr-8 cursor-pointer"
                         onClick={toggleCollapse}
                     >
-                        {label} {sub && `(${sub})`}
+                        {displayLabel} {sub && `(${sub})`}
                     </SidebarGroupLabel>
                     <SidebarGroupContent
                         className={cn(

--- a/src/components/cards/matching.tsx
+++ b/src/components/cards/matching.tsx
@@ -6,6 +6,7 @@ import CustomInitDialog from "@/components/CustomInitDialog";
 import { LatitudeLongitude } from "@/components/LatLngPicker";
 import PresetsDialog from "@/components/PresetsDialog";
 import { Checkbox } from "@/components/ui/checkbox";
+import { FriendlyNameInput } from "@/components/ui/display-name";
 import { Label } from "@/components/ui/label";
 import { Select } from "@/components/ui/select";
 import {
@@ -20,7 +21,6 @@ import {
     hiderMode,
     isLoading,
     questionModified,
-    questions,
     triggerLocalRefresh,
 } from "@/lib/context";
 import { cn } from "@/lib/utils";
@@ -50,7 +50,6 @@ export const MatchingQuestionComponent = ({
 }) => {
     useStore(triggerLocalRefresh);
     const $hiderMode = useStore(hiderMode);
-    const $questions = useStore(questions);
     const $displayHidingZones = useStore(displayHidingZones);
     const $drawingQuestionKey = useStore(drawingQuestionKey);
     const $isLoading = useStore(isLoading);
@@ -59,13 +58,7 @@ export const MatchingQuestionComponent = ({
     const [pendingCustomType, setPendingCustomType] = React.useState<
         "custom-zone" | "custom-points" | null
     >(null);
-    const label = `Matching
-    ${
-        $questions
-            .filter((q) => q.id === "matching")
-            .map((q) => q.key)
-            .indexOf(questionKey) + 1
-    }`;
+    let label = `Matching ${data.type}?`;
 
     let questionSpecific = <></>;
 
@@ -179,6 +172,7 @@ export const MatchingQuestionComponent = ({
         <QuestionCard
             questionKey={questionKey}
             label={label}
+            friendlyName={data.friendlyName}
             sub={sub}
             className={className}
             collapsed={data.collapsed}
@@ -232,7 +226,17 @@ export const MatchingQuestionComponent = ({
                     }
                     data.type = pendingCustomType;
                     questionModified();
+                    label = `Matching ${data.type}?`;
                     setCustomDialogOpen(false);
+                }}
+            />
+            <FriendlyNameInput
+                defaultDisplayName={label}
+                data={data}
+                isLoading={$isLoading}
+                onChange={(newVal) => {
+                    data.friendlyName = newVal;
+                    questionModified(data);
                 }}
             />
             <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
@@ -343,6 +347,7 @@ export const MatchingQuestionComponent = ({
                                 (data as any).cat = { adminLevel: 3 };
                             }
                             questionModified((data.type = value));
+                            label = `Matching ${data.type}?`;
                             return;
                         }
 

--- a/src/components/cards/measuring.tsx
+++ b/src/components/cards/measuring.tsx
@@ -6,6 +6,7 @@ import CustomInitDialog from "@/components/CustomInitDialog";
 import { LatitudeLongitude } from "@/components/LatLngPicker";
 import PresetsDialog from "@/components/PresetsDialog";
 import { Checkbox } from "@/components/ui/checkbox";
+import { FriendlyNameInput } from "@/components/ui/display-name";
 import { Select } from "@/components/ui/select";
 import {
     MENU_ITEM_CLASSNAME,
@@ -19,7 +20,6 @@ import {
     hiderMode,
     isLoading,
     questionModified,
-    questions,
     triggerLocalRefresh,
 } from "@/lib/context";
 import { cn } from "@/lib/utils";
@@ -46,19 +46,16 @@ export const MeasuringQuestionComponent = ({
 }) => {
     useStore(triggerLocalRefresh);
     const $hiderMode = useStore(hiderMode);
-    const $questions = useStore(questions);
     const $displayHidingZones = useStore(displayHidingZones);
     const $drawingQuestionKey = useStore(drawingQuestionKey);
     const $isLoading = useStore(isLoading);
     const $customInitPref = useStore(customInitPreference);
     const [customDialogOpen, setCustomDialogOpen] = React.useState(false);
-    const label = `Measuring
-    ${
-        $questions
-            .filter((q) => q.id === "measuring")
-            .map((q) => q.key)
-            .indexOf(questionKey) + 1
-    }`;
+
+    let label =
+        data.type === "custom-measure"
+            ? "Custom measuring"
+            : `Measuring: closer to ${data.type}?`;
 
     let questionSpecific = <></>;
 
@@ -127,6 +124,7 @@ export const MeasuringQuestionComponent = ({
         <QuestionCard
             questionKey={questionKey}
             label={label}
+            friendlyName={data.friendlyName}
             sub={sub}
             className={className}
             collapsed={data.collapsed}
@@ -164,6 +162,15 @@ export const MeasuringQuestionComponent = ({
                     data.type = "custom-measure";
                     questionModified();
                     setCustomDialogOpen(false);
+                }}
+            />
+            <FriendlyNameInput
+                defaultDisplayName={label}
+                data={data}
+                isLoading={$isLoading}
+                onChange={(newVal) => {
+                    data.friendlyName = newVal;
+                    questionModified(data);
                 }}
             />
             <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
@@ -247,10 +254,12 @@ export const MeasuringQuestionComponent = ({
                             }
                             data.type = value;
                             questionModified();
+                            label = "Custom measuring";
                             return;
                         }
                         data.type = value;
                         questionModified();
+                        label = `Measuring: closer to ${data.type}?`;
                     }}
                     disabled={!data.drag || $isLoading}
                 />

--- a/src/components/cards/radius.tsx
+++ b/src/components/cards/radius.tsx
@@ -1,6 +1,7 @@
 import { useStore } from "@nanostores/react";
 
 import { LatitudeLongitude } from "@/components/LatLngPicker";
+import { FriendlyNameInput } from "@/components/ui/display-name";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -13,7 +14,6 @@ import {
     hiderMode,
     isLoading,
     questionModified,
-    questions,
     triggerLocalRefresh,
 } from "@/lib/context";
 import { cn } from "@/lib/utils";
@@ -34,20 +34,14 @@ export const RadiusQuestionComponent = ({
 }) => {
     useStore(triggerLocalRefresh);
     const $hiderMode = useStore(hiderMode);
-    const $questions = useStore(questions);
     const $isLoading = useStore(isLoading);
-    const label = `Radius
-    ${
-        $questions
-            .filter((q) => q.id === "radius")
-            .map((q) => q.key)
-            .indexOf(questionKey) + 1
-    }`;
+    let label = `${data.radius} ${data.unit} radius`;
 
     return (
         <QuestionCard
             questionKey={questionKey}
             label={label}
+            friendlyName={data.friendlyName}
             sub={sub}
             className={className}
             collapsed={data.collapsed}
@@ -57,6 +51,15 @@ export const RadiusQuestionComponent = ({
             locked={!data.drag}
             setLocked={(locked) => questionModified((data.drag = !locked))}
         >
+            <FriendlyNameInput
+                defaultDisplayName={label}
+                data={data}
+                isLoading={$isLoading}
+                onChange={(newVal) => {
+                    data.friendlyName = newVal;
+                    questionModified(data);
+                }}
+            />
             <SidebarMenuItem>
                 <div className={cn(MENU_ITEM_CLASSNAME, "gap-2 flex flex-row")}>
                     <Input
@@ -64,18 +67,20 @@ export const RadiusQuestionComponent = ({
                         className="rounded-md p-2 w-16"
                         value={data.radius}
                         disabled={!data.drag || $isLoading}
-                        onChange={(e) =>
+                        onChange={(e) => {
                             questionModified(
                                 (data.radius = parseFloat(e.target.value)),
-                            )
-                        }
+                            );
+                            label = `${data.radius} ${data.unit} radius`;
+                        }}
                     />
                     <UnitSelect
                         unit={data.unit}
                         disabled={!data.drag || $isLoading}
-                        onChange={(unit) =>
-                            questionModified((data.unit = unit))
-                        }
+                        onChange={(unit) => {
+                            questionModified((data.unit = unit));
+                            label = `${data.radius} ${data.unit} radius`;
+                        }}
                     />
                 </div>
             </SidebarMenuItem>

--- a/src/components/cards/tentacles.tsx
+++ b/src/components/cards/tentacles.tsx
@@ -5,6 +5,7 @@ import { Suspense, use } from "react";
 import { LatitudeLongitude } from "@/components/LatLngPicker";
 import PresetsDialog from "@/components/PresetsDialog";
 import { Checkbox } from "@/components/ui/checkbox";
+import { FriendlyNameInput } from "@/components/ui/display-name";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import {
@@ -17,7 +18,6 @@ import {
     hiderMode,
     isLoading,
     questionModified,
-    questions,
     triggerLocalRefresh,
 } from "@/lib/context";
 import { cn, mapToObj } from "@/lib/utils";
@@ -43,21 +43,15 @@ export const TentacleQuestionComponent = ({
     sub?: string;
     className?: string;
 }) => {
-    const $questions = useStore(questions);
     const $drawingQuestionKey = useStore(drawingQuestionKey);
     const $isLoading = useStore(isLoading);
-    const label = `Tentacles
-    ${
-        $questions
-            .filter((q) => q.id === "tentacles")
-            .map((q) => q.key)
-            .indexOf(questionKey) + 1
-    }`;
+    let label = `${data.locationType} Tentacles`;
 
     return (
         <QuestionCard
             questionKey={questionKey}
             label={label}
+            friendlyName={data.friendlyName}
             sub={sub}
             className={className}
             collapsed={data.collapsed}
@@ -67,6 +61,15 @@ export const TentacleQuestionComponent = ({
             locked={!data.drag}
             setLocked={(locked) => questionModified((data.drag = !locked))}
         >
+            <FriendlyNameInput
+                defaultDisplayName={label}
+                data={data}
+                isLoading={$isLoading}
+                onChange={(newVal) => {
+                    data.friendlyName = newVal;
+                    questionModified(data);
+                }}
+            />
             <SidebarMenuItem>
                 <div className={cn(MENU_ITEM_CLASSNAME, "gap-2 flex flex-row")}>
                     <Input
@@ -138,6 +141,7 @@ export const TentacleQuestionComponent = ({
                             data.locationType = value;
                         }
                         questionModified();
+                        label = `${data.locationType} Tentacles`;
                     }}
                     disabled={!data.drag || $isLoading}
                 />

--- a/src/components/cards/thermometer.tsx
+++ b/src/components/cards/thermometer.tsx
@@ -1,6 +1,7 @@
 import { useStore } from "@nanostores/react";
 
 import { LatitudeLongitude } from "@/components/LatLngPicker";
+import { FriendlyNameInput } from "@/components/ui/display-name";
 import { Label } from "@/components/ui/label";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
@@ -42,6 +43,7 @@ export const ThermometerQuestionComponent = ({
         <QuestionCard
             questionKey={questionKey}
             label={label}
+            friendlyName={data.friendlyName}
             sub={sub}
             className={className}
             collapsed={data.collapsed}
@@ -51,6 +53,15 @@ export const ThermometerQuestionComponent = ({
             locked={!data.drag}
             setLocked={(locked) => questionModified((data.drag = !locked))}
         >
+            <FriendlyNameInput
+                defaultDisplayName={label}
+                data={data}
+                isLoading={$isLoading}
+                onChange={(newVal) => {
+                    data.friendlyName = newVal;
+                    questionModified(data);
+                }}
+            />
             <LatitudeLongitude
                 latitude={data.latA}
                 longitude={data.lngA}

--- a/src/components/ui/display-name.tsx
+++ b/src/components/ui/display-name.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+import { cn } from "@/lib/utils";
+
+import { Input } from "./input";
+import { Label } from "./label";
+import { SidebarMenuItem } from "./sidebar-l";
+
+type FriendlyNameInputProps = {
+    defaultDisplayName?: string;
+    data: {
+        friendlyName?: string;
+        drag: boolean;
+    };
+    isLoading: boolean;
+    onChange: (newValue: string) => void;
+};
+
+export const FriendlyNameInput: React.FC<FriendlyNameInputProps> = ({
+    defaultDisplayName,
+    data,
+    isLoading,
+    onChange,
+}) => {
+    return (
+        <SidebarMenuItem>
+            <div className={cn("gap-2 flex flex-row items-center gap-2", "MENU_ITEM_CLASSNAME")}>
+                <Label
+                    className={cn(
+                        "font-semibold text-m",
+                        isLoading && "text-muted-foreground",
+                    )}
+                >
+                    Display Name
+                </Label>
+                <Input
+                    type="string"
+                    className="rounded-md p-2 w-32"
+                    placeholder={defaultDisplayName}
+                    value={data.friendlyName}
+                    disabled={!data.drag || isLoading}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            </div>
+        </SidebarMenuItem>
+    );
+};

--- a/src/maps/api/constants.ts
+++ b/src/maps/api/constants.ts
@@ -1,7 +1,6 @@
 import type { APILocations } from "@/maps/schema";
 
-export const OVERPASS_API =
-    "https://overpass-api.de/api/interpreter";
+export const OVERPASS_API = "https://overpass-api.de/api/interpreter";
 export const GEOCODER_API = "https://photon.komoot.io/api/";
 export const PASTEBIN_API_POST_URL =
     "https://cors-anywhere.com/https://pastebin.com/api/api_post.php";

--- a/src/maps/schema.ts
+++ b/src/maps/schema.ts
@@ -66,6 +66,7 @@ const thermometerQuestionSchema = z.object({
     /** Note that drag is now synonymous with unlocked */
     drag: z.boolean().default(true),
     collapsed: z.boolean().default(false),
+    friendlyName: z.string().optional(),
 });
 
 const ordinaryBaseQuestionSchema = z.object({
@@ -81,6 +82,7 @@ const ordinaryBaseQuestionSchema = z.object({
     drag: z.boolean().default(true),
     color: iconColorSchema.default(randomColor),
     collapsed: z.boolean().default(false),
+    friendlyName: z.string().optional(),
 });
 
 const getDefaultUnit = () => {


### PR DESCRIPTION
Hi @taibeled ! 

Love the app - I used it in London for a two day game last weekend and it worked a treat!

I'm just dipping my toes in with a simple PR - I am no frontend developer!

I've added the ability to give custom names to questions for ease of navigation
I've also given the questions better default names, as opposed to e.g. "Radius 1" etc.

<img width="222" height="667" alt="image" src="https://github.com/user-attachments/assets/1d446429-1a63-4570-b8eb-b0b956ff2bf0" />

<img width="229" height="211" alt="image" src="https://github.com/user-attachments/assets/7571b872-cfa4-4852-8667-38f6a218fe66" />

I found that when using the website I had multiple e.g., "Matching 1" and "Matching 2" and could not remember what they were. This gives a more useful default name (which dynamically updates when the parameters change), and can be overwritten by the user if they so wish.

One issue I still have is that I am using the `data.type` for the matching question which gives names such as "Measuring: closer to zoo-full" over "measuring: closer to zoo", which is not as nice. If I have more time i will add a human readable field to all the data types.

Let me know what you think!

Andrew