### PR TITLE
Added checkbox to merge duplicated stations

### DIFF
--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -131,13 +131,13 @@ export const customStations = persistentAtom<CustomStation[]>(
         decode: JSON.parse,
     },
 );
-export const removeDuplicates = persistentAtom<boolean>(
+export const mergeDuplicates = persistentAtom<boolean>(
     "removeDuplicates",
     false,
     {
         encode: JSON.stringify,
         decode: JSON.parse,
-    }, 
+    },
 );
 export const includeDefaultStations = persistentAtom<boolean>(
     "includeDefaultStations",

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -131,6 +131,14 @@ export const customStations = persistentAtom<CustomStation[]>(
         decode: JSON.parse,
     },
 );
+export const removeDuplicates = persistentAtom<boolean>(
+    "removeDuplicates",
+    false,
+    {
+        encode: JSON.stringify,
+        decode: JSON.parse,
+    }, 
+);
 export const includeDefaultStations = persistentAtom<boolean>(
     "includeDefaultStations",
     false,

--- a/src/maps/geo-utils/index.ts
+++ b/src/maps/geo-utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./operators";
 export * from "./special";
+export * from "./stationManipulations";

--- a/src/maps/geo-utils/stationManipulations.ts
+++ b/src/maps/geo-utils/stationManipulations.ts
@@ -1,0 +1,32 @@
+// Function to merge duplicates stations into one station, by averaging their longitude and latitude
+export function mergeDuplicateStation(places: any[]) {
+    const grouped = new Map<string, any[]>();
+    // 1. Group by name
+    places.forEach((place) => {
+        const name = place.properties.name;
+        if (!grouped.has(name)) {
+            grouped.set(name, []);
+        }
+        grouped.get(name)!.push(place);
+    });
+
+    // 2. Compute central point per group
+    const merged: any[] = [];
+    grouped.forEach((group) => {
+        const avgLng =
+            group.reduce((sum, p) => sum + p.geometry.coordinates[0], 0) /
+            group.length;
+        const avgLat =
+            group.reduce((sum, p) => sum + p.geometry.coordinates[1], 0) /
+            group.length;
+
+        merged.push({
+            ...group[0], // copy other fields from the first feature
+            geometry: {
+                type: "Point",
+                coordinates: [avgLng, avgLat],
+            },
+        });
+    });
+    return merged;
+}

--- a/tests/stationManipulations.test.ts
+++ b/tests/stationManipulations.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+
+import { mergeDuplicateStation } from "../src/maps/geo-utils/stationManipulations";
+
+describe("mergeDuplicateStation", () => {
+    it("merges duplicates in the eastern hemisphere", () => {
+        const places = [
+            {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [120, 10] },
+                properties: { name: "Station East" },
+            },
+            {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [122, 12] },
+                properties: { name: "Station East" },
+            },
+        ];
+
+        const result = mergeDuplicateStation(places);
+        expect(result).toHaveLength(1);
+        expect(result[0].geometry.coordinates).toEqual([121, 11]); // average
+    });
+
+    it("merges duplicates in the western hemisphere", () => {
+        const places = [
+            {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [-80, 25] },
+                properties: { name: "Station West" },
+            },
+            {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [-82, 23] },
+                properties: { name: "Station West" },
+            },
+        ];
+
+        const result = mergeDuplicateStation(places);
+        expect(result).toHaveLength(1);
+        expect(result[0].geometry.coordinates).toEqual([-81, 24]);
+    });
+
+    it("merges duplicates in the southern hemisphere", () => {
+        const places = [
+            {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [30, -20] },
+                properties: { name: "Station South" },
+            },
+            {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [32, -22] },
+                properties: { name: "Station South" },
+            },
+        ];
+
+        const result = mergeDuplicateStation(places);
+        expect(result).toHaveLength(1);
+        expect(result[0].geometry.coordinates).toEqual([31, -21]);
+    });
+
+    it("handles 3 or more duplicates", () => {
+        const places = [
+            {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [10, 10] },
+                properties: { name: "Station Multi" },
+            },
+            {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [20, 20] },
+                properties: { name: "Station Multi" },
+            },
+            {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [30, 30] },
+                properties: { name: "Station Multi" },
+            },
+        ];
+
+        const result = mergeDuplicateStation(places);
+        expect(result).toHaveLength(1);
+        expect(result[0].geometry.coordinates).toEqual([20, 20]); // average of 10,20,30
+    });
+
+    it("returns all places unchanged when all names are unique", () => {
+        const places = [
+            {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [10, 50] },
+                properties: { name: "Unique A" },
+            },
+            {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [20, -30] },
+                properties: { name: "Unique B" },
+            },
+            {
+                type: "Feature",
+                geometry: { type: "Point", coordinates: [-40, 60] },
+                properties: { name: "Unique C" },
+            },
+        ];
+
+        const result = mergeDuplicateStation(places);
+        expect(result).toHaveLength(3);
+
+        // Make sure the coordinates are preserved exactly
+        expect(result.map((r) => r.geometry.coordinates)).toEqual([
+            [10, 50],
+            [20, -30],
+            [-40, 60],
+        ]);
+    });
+});


### PR DESCRIPTION
In Switzerland, OpenStreeMap is very detailed and so most tram and bus stations exist multiple times (because there is a stop on each side of the street).
This creates a lot of duplicated hiding zones.

I added a checkbox (``Merge duplicated stations?``) allowing to merge duplicated stations. The function merges stations based on the names and then calculates the average longitude and latitude to place the merged station. Toggling the checkbox, re-triggers the fetching of the stations.

Added a function to do the calculation and added unit tests (full disclosure: ChatGPT was helping with that part).

Please let me know if this PR suits your vision or I should change anything (like the location of the checkbox).


*Btw: Great tool and amazing to have it as an OpenSource project! Great work! :)*

# Pictures
*Issue of duplicated hiding zones:*
<img width="1405" height="916" alt="image" src="https://github.com/user-attachments/assets/89fd121a-b61e-4ba5-98e6-14c85619e0cb" />
<img width="1404" height="915" alt="image" src="https://github.com/user-attachments/assets/e6e3b533-71e2-4710-a44c-0279febeb038" />


*Merged stations:*
<img width="1407" height="922" alt="image" src="https://github.com/user-attachments/assets/505be28d-68fc-4e3a-b954-73dbdb1e1ef4" />
<img width="1405" height="918" alt="image" src="https://github.com/user-attachments/assets/5019568c-ad3b-4034-9a9c-9f35aba20a7a" />


*Added checkbox:*
<img width="244" height="265" alt="image" src="https://github.com/user-attachments/assets/994070a7-bd88-4acc-a696-402802b26af1" />

