### PR TITLE
Fix for #167: Merging stations based on zone overlap

### DIFF
--- a/src/components/ZoneSidebar.tsx
+++ b/src/components/ZoneSidebar.tsx
@@ -258,7 +258,11 @@ export const ZoneSidebar = () => {
 
             // merge duplicate stations if selected
             if (mergeDuplicates) {
-                places = mergeDuplicateStation(places);
+                places = mergeDuplicateStation(
+                    places,
+                    $hidingRadius,
+                    $hidingRadiusUnits,
+                );
             }
 
             const unionized = safeUnion(

--- a/src/maps/geo-utils/stationManipulations.ts
+++ b/src/maps/geo-utils/stationManipulations.ts
@@ -1,16 +1,80 @@
 import * as turf from "@turf/turf";
 
-// Function to merge duplicates stations into one station, by averaging their longitude and latitude
-export function mergeDuplicateStation(places: any[]) {
+/**
+ * Function to merge duplicates stations into one station, by averaging their longitude and latitude
+ * @param places    Array of all unmerged stations
+ * @param radius    Radius of the hiding zone
+ * @param units     turf.Units unit of the radius ("miles", "kilometers" etc.)
+ * @returns         Array of all merged stations
+ */
+export function mergeDuplicateStation(
+    places: any[],
+    radius: number,
+    units: turf.Units,
+): any[] {
     const grouped = new Map<string, any[]>();
     // 1. Group by name
-    places.forEach((place) => {
+    for (const place of places) {
         const name = place.properties.name;
+        // Check if the group already exist, if not add a new group entry.
         if (!grouped.has(name)) {
-            grouped.set(name, []);
+            grouped.set(name, [place]);
+        } else {
+            // group already exist, need to check all groups and all members if their zones are shared
+            let placeAdded = false;
+            for (const group of grouped) {  // check all groups
+                const groupValues = group[1];
+
+                // if the name matches the first group members name, check all members
+                if (groupValues[0].properties.name == name) {   
+                    let shareZones: boolean = false;
+                    for (const groupPlace of groupValues) {
+                        const station1: Location = {
+                            coordinates: place.geometry.coordinates,
+                        };
+                        const station2: Location = {
+                            coordinates: groupPlace.geometry.coordinates,
+                        };
+                        shareZones = checkIfStationsShareZones(
+                            station1,
+                            station2,
+                            radius,
+                            units,
+                        );
+                        if (!shareZones) {
+                            // new zone does not overlap with a station, leave early
+                            break;
+                        }
+                    }
+                    if (shareZones) {
+                        // add to group if all stations share the zone
+                        groupValues.push(place);
+                        placeAdded = true;
+                        break; // leave group search, as the new place is already added
+                    }
+                }
+            }
+
+            if (!placeAdded) {
+                // if we arrive here, we need to make a new group with a unique key
+
+                // searching for all groups containing the station name to find latest index
+                const matches = Array.from(grouped.entries()).filter(
+                    ([key]) => typeof key === "string" && key.includes(name),
+                );
+                const lastGroup = matches.at(-1);   // last group has the latest index
+                let lastKey = "0";
+                if (lastGroup) {
+                    lastKey = lastGroup[0];
+                }
+                const lastIdx = Number(lastKey.split("#")[1] ?? "0");
+                const nextIdx = lastIdx + 1;
+                const key: string = name + "#" + nextIdx.toString();
+                // New key example: "Station Name#1"
+                grouped.set(key, [place]);
+            }
         }
-        grouped.get(name)!.push(place);
-    });
+    }
 
     // 2. Compute central point per group
     const merged: any[] = [];

--- a/src/maps/geo-utils/stationManipulations.ts
+++ b/src/maps/geo-utils/stationManipulations.ts
@@ -1,3 +1,5 @@
+import * as turf from "@turf/turf";
+
 // Function to merge duplicates stations into one station, by averaging their longitude and latitude
 export function mergeDuplicateStation(places: any[]) {
     const grouped = new Map<string, any[]>();
@@ -29,4 +31,48 @@ export function mergeDuplicateStation(places: any[]) {
         });
     });
     return merged;
+}
+
+// Location object definition
+export type Location = {
+    name?: string;
+    type?: string;
+    coordinates: number[]; // [longitude, latitude]
+};
+
+/**
+ * Check if two stations share a zone in a way that both centers are inside the others radius.
+ * Both stations must lie within the given radius of each other.
+ *
+ * Matches:
+ *      (...{Z1..Z2)...}
+ * Does not match:
+ *      (....Z1....) {....Z2....}
+ * @param station1 First station location.
+ * @param station2 Second station location.
+ * @param radius   The zone radius around each station.
+ * @param units    The unit for the radius ("miles","kilometers", "meters").
+ * @returns        True if both stations share a zone, otherwise false.
+ */
+export function checkIfStationsShareZones(
+    station1: Location,
+    station2: Location,
+    radius: number,
+    units: turf.Units,
+): boolean {
+    // Convert to turf points
+    const point1 = turf.point([
+        station1.coordinates[0],
+        station1.coordinates[1],
+    ]);
+    const point2 = turf.point([
+        station2.coordinates[0],
+        station2.coordinates[1],
+    ]);
+
+    // Distance of the 2 center points
+    const d = turf.distance(point1, point2, { units });
+
+    // If the distance of the 2 center points is smaller or equal of the radius, the 2 zones overlap.
+    return d <= radius;
 }

--- a/tests/stationManipulations.test.ts
+++ b/tests/stationManipulations.test.ts
@@ -16,8 +16,10 @@ describe("mergeDuplicateStation", () => {
                 properties: { name: "Station East" },
             },
         ];
+        const radius = 10000; // super wide radius to ensure all locations are in
+        const units: turf.Units = "kilometers";
 
-        const result = mergeDuplicateStation(places);
+        const result = mergeDuplicateStation(places, radius, units);
         expect(result).toHaveLength(1);
         expect(result[0].geometry.coordinates).toEqual([121, 11]); // average
     });
@@ -35,8 +37,10 @@ describe("mergeDuplicateStation", () => {
                 properties: { name: "Station West" },
             },
         ];
+        const radius = 10000; // super wide radius to ensure all locations are in
+        const units: turf.Units = "kilometers";
 
-        const result = mergeDuplicateStation(places);
+        const result = mergeDuplicateStation(places, radius, units);
         expect(result).toHaveLength(1);
         expect(result[0].geometry.coordinates).toEqual([-81, 24]);
     });
@@ -54,8 +58,10 @@ describe("mergeDuplicateStation", () => {
                 properties: { name: "Station South" },
             },
         ];
+        const radius = 10000; // super wide radius to ensure all locations are in
+        const units: turf.Units = "kilometers";
 
-        const result = mergeDuplicateStation(places);
+        const result = mergeDuplicateStation(places, radius, units);
         expect(result).toHaveLength(1);
         expect(result[0].geometry.coordinates).toEqual([31, -21]);
     });
@@ -78,8 +84,10 @@ describe("mergeDuplicateStation", () => {
                 properties: { name: "Station Multi" },
             },
         ];
+        const radius = 10000; // super wide radius to ensure all locations are in
+        const units: turf.Units = "kilometers";
 
-        const result = mergeDuplicateStation(places);
+        const result = mergeDuplicateStation(places, radius, units);
         expect(result).toHaveLength(1);
         expect(result[0].geometry.coordinates).toEqual([20, 20]); // average of 10,20,30
     });
@@ -102,8 +110,10 @@ describe("mergeDuplicateStation", () => {
                 properties: { name: "Unique C" },
             },
         ];
+        const radius = 10000; // super wide radius to ensure all locations are in
+        const units: turf.Units = "kilometers";
 
-        const result = mergeDuplicateStation(places);
+        const result = mergeDuplicateStation(places, radius, units);
         expect(result).toHaveLength(3);
 
         // Make sure the coordinates are preserved exactly
@@ -112,6 +122,65 @@ describe("mergeDuplicateStation", () => {
             [20, -30],
             [-40, 60],
         ]);
+    });
+
+    it("returns 3 individual zones when 6 Jan van Galenstraat stations are added, where only 2 stations share the actual zone", () => {
+        const places = [
+            {
+                // West station 1:      https://www.openstreetmap.org/node/3306520727
+                geometry: {
+                    type: "Point",
+                    coordinates: [4.8350051, 52.3732337],
+                },
+                properties: { name: "Jan van Galenstraat" },
+            },
+            {
+                // West station 2:      https://www.openstreetmap.org/node/434662863
+                geometry: {
+                    type: "Point",
+                    coordinates: [4.8359077, 52.3730297],
+                },
+                properties: { name: "Jan van Galenstraat" },
+            },
+            {
+                // Center station 1:    https://www.openstreetmap.org/node/434700014
+                geometry: {
+                    type: "Point",
+                    coordinates: [4.8485891, 52.3733319],
+                },
+                properties: { name: "Jan van Galenstraat" },
+            },
+            {
+                // Center station 2:    https://www.openstreetmap.org/node/3300515588
+                geometry: {
+                    type: "Point",
+                    coordinates: [4.8487242, 52.3729826],
+                },
+                properties: { name: "Jan van Galenstraat" },
+            },
+            {
+                // East station 1:      https://www.openstreetmap.org/node/434397634
+                geometry: {
+                    type: "Point",
+                    coordinates: [4.8584711, 52.3751323],
+                },
+                properties: { name: "Jan van Galenstraat" },
+            },
+            {
+                // East station 2:      https://www.openstreetmap.org/node/434397635
+                geometry: {
+                    type: "Point",
+                    coordinates: [4.8586427, 52.3743002],
+                },
+                properties: { name: "Jan van Galenstraat" },
+            },
+        ];
+        const radius = 0.5;
+        const units: turf.Units = "kilometers";
+
+        const result = mergeDuplicateStation(places, radius, units);
+        // We expect 3 stations, because the 3 pairs are very far apart
+        expect(result).toHaveLength(3);
     });
 });
 
@@ -123,11 +192,11 @@ describe("checkIfStationsShareZones", () => {
     it("returns true that Jan van Galenstraat subway station and nearby tram station share zones with km as unit", () => {
         // Subway station:      https://www.openstreetmap.org/node/250224485
         const station1: Location = {
-            coordinates: [52.3726582, 4.8352937],
+            coordinates: [4.8352937, 52.3726582],
         };
         // Nearby tram station: https://www.openstreetmap.org/node/3306520727
         const station2: Location = {
-            coordinates: [52.3732337, 4.8350051],
+            coordinates: [4.8350051, 52.3732337],
         };
         const radius: number = 0.5; //km
         const units: turf.Units = "kilometers";
@@ -143,11 +212,11 @@ describe("checkIfStationsShareZones", () => {
     it("returns false that Jan van Galenstraat subway station and far away tram station share zones with km as unit", () => {
         // Subway station:      https://www.openstreetmap.org/node/250224485
         const station1: Location = {
-            coordinates: [52.3726582, 4.8352937],
+            coordinates: [4.8352937, 52.3726582],
         };
         // Far away tram station: https://www.openstreetmap.org/node/3300515588
         const station2: Location = {
-            coordinates: [52.3729826, 4.8487242],
+            coordinates: [4.8487242, 52.3729826],
         };
         const radius: number = 0.5; //km
         const units: turf.Units = "kilometers";
@@ -163,11 +232,11 @@ describe("checkIfStationsShareZones", () => {
     it("returns false that Jan van Galenstraat subway station and far away tram station share zones with miles as unit", () => {
         // Subway station:      https://www.openstreetmap.org/node/250224485
         const station1: Location = {
-            coordinates: [52.3726582, 4.8352937],
+            coordinates: [4.8352937, 52.3726582],
         };
         // Far away tram station: https://www.openstreetmap.org/node/3300515588
         const station2: Location = {
-            coordinates: [52.3729826, 4.8487242],
+            coordinates: [4.8487242, 52.3729826],
         };
         const radius: number = 0.5; //km
         const units: turf.Units = "miles";

--- a/tests/stationManipulations.test.ts
+++ b/tests/stationManipulations.test.ts
@@ -114,3 +114,69 @@ describe("mergeDuplicateStation", () => {
         ]);
     });
 });
+
+import { checkIfStationsShareZones } from "../src/maps/geo-utils/stationManipulations";
+import type { Location } from "../src/maps/geo-utils/stationManipulations";
+import * as turf from "@turf/turf";
+
+describe("checkIfStationsShareZones", () => {
+    it("returns true that Jan van Galenstraat subway station and nearby tram station share zones with km as unit", () => {
+        // Subway station:      https://www.openstreetmap.org/node/250224485
+        const station1: Location = {
+            coordinates: [52.3726582, 4.8352937],
+        };
+        // Nearby tram station: https://www.openstreetmap.org/node/3306520727
+        const station2: Location = {
+            coordinates: [52.3732337, 4.8350051],
+        };
+        const radius: number = 0.5; //km
+        const units: turf.Units = "kilometers";
+        const result = checkIfStationsShareZones(
+            station1,
+            station2,
+            radius,
+            units,
+        );
+        expect(result).true;
+    });
+
+    it("returns false that Jan van Galenstraat subway station and far away tram station share zones with km as unit", () => {
+        // Subway station:      https://www.openstreetmap.org/node/250224485
+        const station1: Location = {
+            coordinates: [52.3726582, 4.8352937],
+        };
+        // Far away tram station: https://www.openstreetmap.org/node/3300515588
+        const station2: Location = {
+            coordinates: [52.3729826, 4.8487242],
+        };
+        const radius: number = 0.5; //km
+        const units: turf.Units = "kilometers";
+        const result = checkIfStationsShareZones(
+            station1,
+            station2,
+            radius,
+            units,
+        );
+        expect(result).false;
+    });
+
+    it("returns false that Jan van Galenstraat subway station and far away tram station share zones with miles as unit", () => {
+        // Subway station:      https://www.openstreetmap.org/node/250224485
+        const station1: Location = {
+            coordinates: [52.3726582, 4.8352937],
+        };
+        // Far away tram station: https://www.openstreetmap.org/node/3300515588
+        const station2: Location = {
+            coordinates: [52.3729826, 4.8487242],
+        };
+        const radius: number = 0.5; //km
+        const units: turf.Units = "miles";
+        const result = checkIfStationsShareZones(
+            station1,
+            station2,
+            radius,
+            units,
+        );
+        expect(result).false;
+    });
+});


### PR DESCRIPTION
Fixes #167 
@quixoticgeek

# Description:
This PR fixes the issue when stations with the same name are far apart and don't really share a hiding zone. Now such stations will be split in individual zones. 

## Added:
- Function ``checkIfStationsShareZones`` that checks if 2 stations share hiding zones. Their centers need to be in each others radius.

## Changed:
- Function ``mergeDuplicateStation`` was changed to check each duplicated station if it shares the hiding zone (by utilizing ``checkIfStationsShareZones``), if not, a separate individual station is created.

## Note
The function ``checkIfStationsShareZones`` could be used in the future to create a filter algorithm to reduce the number of stations in densely populated areas, specially when playing with local transit options (such as trams or buses).

## Improvement possibilities:
In the case where stations are in a line but only the center station share zones with the outer stations (see example with big hiding zones below), the argument could be made that they should be merged into just one zone in the center.

At this moment, I don't really know how to achieve this and thought that the current implementation should be sufficient. Let me know, if I should try to implement it in that way (will probably take a bit thou).

# Testing
Unit tests for the new function and the edge case of the bug are where added.

## Visual testing
Unmerged stations:
<img width="1653" height="918" alt="JanVanGalenstraatUnmerged" src="https://github.com/user-attachments/assets/0b7bf81f-201f-45e9-8a79-8d90d0cbc826" />

Merged stations:
<img width="1654" height="916" alt="JanVanGalenstraatMerged" src="https://github.com/user-attachments/assets/09502a87-7a48-4bf5-8d88-ad1f2650d106" />

Bigger radius, where the center stations overlap both exterior stations:
<img width="1659" height="915" alt="ZonesInLineUnmerged" src="https://github.com/user-attachments/assets/0f6695d3-6234-44dd-8f00-617b9bcffa1c" />

Bigger radius, merged into 2 zones (center stations are assigned to exterior stations, based on station index, basically randomly):
<img width="1651" height="917" alt="ZonesInLineMerged" src="https://github.com/user-attachments/assets/8e5ba5a8-3507-48e8-8162-ad3883bcad9d" />

