### PR TITLE
fix: `@nanostores/persistent` error with node 25 (#184)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Even if you're not a programmer, you can still help by further documenting the u
 
 ## Developer Workflow
 
-To develop this website, you need to have [git](https://git-scm.com/downloads) and [pnpm](https://pnpm.io/installation) installed. You should then start by cloning this repository and entering the directory:
+To develop this website, you need to have [git](https://git-scm.com/downloads), [Node.js](https://nodejs.org/) (version 24 or earlier), and [pnpm](https://pnpm.io/installation) installed. You should then start by cloning this repository and entering the directory:
 
 ```bash
 git clone https://github.com/taibeled/JetLagHideAndSeek.git

--- a/package.json
+++ b/package.json
@@ -78,5 +78,8 @@
         "prettier": "3.5.3",
         "typescript-eslint": "^8.24.0",
         "vitest": "^3.1.4"
+    },
+    "engines": {
+        "node": "<25"
     }
 }


### PR DESCRIPTION
adds a note to use node versions before 25, also adds it to the `package.json` so on runs a warning shows up