### PR TITLE
Add display for distance between start and end points in thermometer question

### DIFF
--- a/src/components/cards/thermometer.tsx
+++ b/src/components/cards/thermometer.tsx
@@ -1,8 +1,10 @@
 import { useStore } from "@nanostores/react";
-import { defaultUnit } from "@/lib/context";
+import { distance, point } from "@turf/turf";
+
 import { LatitudeLongitude } from "@/components/LatLngPicker";
 import { Label } from "@/components/ui/label";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { defaultUnit } from "@/lib/context";
 import {
     hiderMode,
     isLoading,
@@ -14,17 +16,6 @@ import { cn } from "@/lib/utils";
 import type { ThermometerQuestion } from "@/maps/schema";
 
 import { QuestionCard } from "./base";
-
-/* ---- distance helpers (turf) ---- */
-import distance from "@turf/distance";
-import { point } from "@turf/helpers";
-/* -------------------------------- */
-
-const VALID_UNITS = ["miles", "kilometers", "meters"] as const;
-type ValidUnit = (typeof VALID_UNITS)[number];
-
-const normalizeUnit = (unit: string): ValidUnit =>
-    VALID_UNITS.includes(unit as ValidUnit) ? (unit as ValidUnit) : "miles";
 
 export const ThermometerQuestionComponent = ({
     data,
@@ -42,9 +33,8 @@ export const ThermometerQuestionComponent = ({
     const $questions = useStore(questions);
     const $isLoading = useStore(isLoading);
 
-    // normalize external string into something turf accepts
     const $defaultUnit = useStore(defaultUnit);
-    const DISTANCE_UNIT = normalizeUnit($defaultUnit ?? "miles");
+    const DISTANCE_UNIT = $defaultUnit ?? "miles";
 
     const label = `Thermometer
     ${
@@ -64,7 +54,7 @@ export const ThermometerQuestionComponent = ({
         ? distance(
               point([data.lngA!, data.latA!]),
               point([data.lngB!, data.latB!]),
-              { units: DISTANCE_UNIT }
+              { units: DISTANCE_UNIT },
           )
         : null;
 
@@ -72,8 +62,8 @@ export const ThermometerQuestionComponent = ({
         DISTANCE_UNIT === "meters"
             ? "Meters"
             : DISTANCE_UNIT === "kilometers"
-            ? "KM"
-            : "Miles";
+              ? "KM"
+              : "Miles";
 
     return (
         <QuestionCard


### PR DESCRIPTION
<img width="1919" height="913" alt="image" src="https://github.com/user-attachments/assets/f04416e5-14ba-48b3-9ab3-3c4bfb340e82" />
Here's an image from a local NPM server I tested on. The addition simply shows the distance in miles, km, and meters based on the latitude and longtitude of the start and end point.
<img width="1915" height="908" alt="image" src="https://github.com/user-attachments/assets/408b0fff-b2e3-4f4a-9ccb-5dff309d1e90" />
