### PR TITLE
Add 'peak' to APILocations schema to support mountain locations

### DIFF
--- a/src/maps/schema.ts
+++ b/src/maps/schema.ts
@@ -132,6 +132,7 @@ const apiLocationSchema = z.union([
     z.literal("golf_course"),
     z.literal("consulate"),
     z.literal("park"),
+    z.literal("peak"),
     tentacleLocationsFifteen,
     tentacleLocationsOne,
 ]);


### PR DESCRIPTION
Should have been done in commit a4759da1

[Missed in https://github.com/taibeled/JetLagHideAndSeek/pull/193 and also no linting etc. spotted it but today my IDE complained]