### PR TITLE
Changeable base map styles

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -14,9 +14,9 @@ import {
     addQuestion,
     animateMapMovements,
     autoZoom,
+    baseTileLayer,
     followMe,
     hiderMode,
-    highlightTrainLines,
     isLoading,
     leafletMapContext,
     mapGeoJSON,
@@ -38,11 +38,87 @@ import { LeafletFullScreenButton } from "./LeafletFullScreenButton";
 import { MapPrint } from "./MapPrint";
 import { PolygonDraw } from "./PolygonDraw";
 
+const getTileLayer = (tileLayer: string, thunderforestApiKey: string) => {
+    switch (tileLayer) {
+        case "light":
+            return (
+                <TileLayer
+                    attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors; &copy; <a href="https://carto.com/attributions">CARTO</a>; Powered by Esri and Turf.js'
+                    url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+                    subdomains="abcd"
+                    maxZoom={20} // This technically should be 6, but once the ratelimiting starts this can take over
+                    minZoom={2}
+                    noWrap
+                />
+            );
+
+        case "dark":
+            return (
+                <TileLayer
+                    attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors; &copy; <a href="https://carto.com/attributions">CARTO</a>; Powered by Esri and Turf.js'
+                    url="https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+                    subdomains="abcd"
+                    maxZoom={20} // This technically should be 6, but once the ratelimiting starts this can take over
+                    minZoom={2}
+                    noWrap
+                />
+            );
+
+        case "transport":
+            if (thunderforestApiKey)
+                return (
+                    <TileLayer
+                        url={`https://tile.thunderforest.com/transport/{z}/{x}/{y}.png?apikey=${thunderforestApiKey}`}
+                        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors; &copy; <a href="http://www.thunderforest.com/">Thunderforest</a>; Powered by Esri and Turf.js'
+                        maxZoom={22}
+                        minZoom={2}
+                        noWrap
+                    />
+                );
+            break;
+
+        case "neighbourhood":
+            if (thunderforestApiKey)
+                return (
+                    <TileLayer
+                        url={`https://tile.thunderforest.com/neighbourhood/{z}/{x}/{y}.png?apikey=${thunderforestApiKey}`}
+                        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors; &copy; <a href="http://www.thunderforest.com/">Thunderforest</a>; Powered by Esri and Turf.js'
+                        maxZoom={22}
+                        minZoom={2}
+                        noWrap
+                    />
+                );
+            break;
+
+        case "osmcarto":
+            return (
+                <TileLayer
+                    attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors; Powered by Esri and Turf.js'
+                    url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+                    maxZoom={19}
+                    minZoom={2}
+                    noWrap
+                />
+            );
+    }
+
+    return (
+        <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors; &copy; <a href="https://carto.com/attributions">CARTO</a>; Powered by Esri and Turf.js'
+            url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+            subdomains="abcd"
+            maxZoom={20} // This technically should be 6, but once the ratelimiting starts this can take over
+            minZoom={2}
+            noWrap
+        />
+    );
+};
+
 export const Map = ({ className }: { className?: string }) => {
     useStore(additionalMapGeoLocations);
     const $mapGeoLocation = useStore(mapGeoLocation);
     const $questions = useStore(questions);
-    const $highlightTrainLines = useStore(highlightTrainLines);
+    const $baseTileLayer = useStore(baseTileLayer);
     const $thunderforestApiKey = useStore(thunderforestApiKey);
     const $hiderMode = useStore(hiderMode);
     const $isLoading = useStore(isLoading);
@@ -290,25 +366,7 @@ export const Map = ({ className }: { className?: string }) => {
                     },
                 ]}
             >
-                {!($highlightTrainLines && $thunderforestApiKey) && (
-                    <TileLayer
-                        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors; &copy; <a href="https://carto.com/attributions">CARTO</a>; &copy; <a href="http://www.thunderforest.com/">Thunderforest</a>; Powered by Esri and Turf.js'
-                        url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
-                        subdomains="abcd"
-                        maxZoom={20} // This technically should be 6, but once the ratelimiting starts this can take over
-                        minZoom={2}
-                        noWrap
-                    />
-                )}
-                {$highlightTrainLines && $thunderforestApiKey && (
-                    <TileLayer
-                        url={`https://tile.thunderforest.com/transport/{z}/{x}/{y}.png?apikey=${$thunderforestApiKey}`}
-                        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors; &copy; <a href="https://carto.com/attributions">CARTO</a>; &copy; <a href="http://www.thunderforest.com/">Thunderforest</a>; Powered by Esri and Turf.js'
-                        maxZoom={22}
-                        minZoom={2}
-                        noWrap
-                    />
-                )}
+                {getTileLayer($baseTileLayer, $thunderforestApiKey)}
                 <DraggableMarkers />
                 <div className="leaflet-top leaflet-right">
                     <div className="leaflet-control flex-col flex gap-2">
@@ -331,7 +389,7 @@ export const Map = ({ className }: { className?: string }) => {
                 />
             </MapContainer>
         ),
-        [map, $highlightTrainLines, $thunderforestApiKey],
+        [map, $baseTileLayer, $thunderforestApiKey],
     );
 
     useEffect(() => {

--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -15,6 +15,7 @@ import {
     animateMapMovements,
     autoSave,
     autoZoom,
+    baseTileLayer,
     customInitPreference,
     customPresets,
     customStations,
@@ -26,7 +27,6 @@ import {
     hidingRadius,
     hidingRadiusUnits,
     hidingZone,
-    highlightTrainLines,
     includeDefaultStations,
     leafletMapContext,
     mapGeoJSON,
@@ -72,13 +72,13 @@ const PASTEBIN_URL_PARAM = "pb";
 export const OptionDrawers = ({ className }: { className?: string }) => {
     useStore(triggerLocalRefresh);
     const $defaultUnit = useStore(defaultUnit);
-    const $highlightTrainLines = useStore(highlightTrainLines);
     const $animateMapMovements = useStore(animateMapMovements);
     const $autoZoom = useStore(autoZoom);
     const $hiderMode = useStore(hiderMode);
     const $autoSave = useStore(autoSave);
     const $hidingZone = useStore(hidingZone);
     const $planningMode = useStore(planningModeEnabled);
+    const $baseTileLayer = useStore(baseTileLayer);
     const $thunderforestApiKey = useStore(thunderforestApiKey);
     const $pastebinApiKey = useStore(pastebinApiKey);
     const $alwaysUsePastebin = useStore(alwaysUsePastebin);
@@ -421,75 +421,48 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                                 }
                             />
                             <Separator className="bg-slate-300 w-[280px]" />
-                            <div className="flex flex-row items-center gap-2">
-                                <label className="text-2xl font-semibold font-poppins">
-                                    Animate map movements?
-                                </label>
-                                <Checkbox
-                                    checked={$animateMapMovements}
-                                    onCheckedChange={() => {
-                                        animateMapMovements.set(
-                                            !$animateMapMovements,
-                                        );
-                                    }}
+                            <Label>Base map style</Label>
+                            <Select
+                                trigger="Base map style"
+                                options={{
+                                    voyager: "CARTO Voyager",
+                                    light: "CARTO Light",
+                                    dark: "CARTO Dark",
+                                    transport: "Thunderforest Transport",
+                                    neighbourhood:
+                                        "Thunderforest Neighbourhood",
+                                    osmcarto: "OpenStreetMap Carto",
+                                }}
+                                value={$baseTileLayer}
+                                onValueChange={(v) =>
+                                    baseTileLayer.set(v as any)
+                                }
+                            />
+                            <div className="flex flex-col items-center gap-2">
+                                <Label>Thunderforest API Key</Label>
+                                <Input
+                                    type="text"
+                                    value={$thunderforestApiKey}
+                                    id="thunderforestApiKey"
+                                    onChange={(e) =>
+                                        thunderforestApiKey.set(e.target.value)
+                                    }
+                                    placeholder="Enter your Thunderforest API key"
                                 />
+                                <p className="text-xs text-gray-500">
+                                    Needed for Thunderforest map styles. Create
+                                    a key{" "}
+                                    <a
+                                        href="https://manage.thunderforest.com/users/sign_up?price=hobby-project-usd"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="text-blue-500 cursor-pointer"
+                                    >
+                                        here.
+                                    </a>{" "}
+                                    Don&apos;t worry, it&apos;s free.
+                                </p>
                             </div>
-                            {$highlightTrainLines && (
-                                <Separator className="bg-slate-300 w-[280px]" />
-                            )}
-                            <div className="flex flex-row items-center gap-2">
-                                <label className="text-2xl font-semibold font-poppins">
-                                    Highlight train lines?
-                                </label>
-                                <Checkbox
-                                    checked={$highlightTrainLines}
-                                    onCheckedChange={() => {
-                                        const willBeEnabled =
-                                            !$highlightTrainLines;
-                                        if (
-                                            willBeEnabled &&
-                                            !$thunderforestApiKey
-                                        ) {
-                                            toast.warn(
-                                                "A Thunderforest API key is required to highlight train lines. Please add one in the options below.",
-                                            );
-                                        }
-                                        highlightTrainLines.set(willBeEnabled);
-                                    }}
-                                />
-                            </div>
-                            {$highlightTrainLines && (
-                                <>
-                                    <div className="flex flex-col items-center gap-2">
-                                        <Label>Thunderforest API Key</Label>
-                                        <Input
-                                            type="text"
-                                            value={$thunderforestApiKey}
-                                            id="thunderforestApiKey"
-                                            onChange={(e) =>
-                                                thunderforestApiKey.set(
-                                                    e.target.value,
-                                                )
-                                            }
-                                            placeholder="Enter your Thunderforest API key"
-                                        />
-                                        <p className="text-xs text-gray-500">
-                                            Needed for highlighting train lines.
-                                            Create a key{" "}
-                                            <a
-                                                href="https://manage.thunderforest.com/users/sign_up?price=hobby-project-usd"
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                className="text-blue-500 cursor-pointer"
-                                            >
-                                                here.
-                                            </a>{" "}
-                                            Don&apos;t worry, it&apos;s free.
-                                        </p>
-                                    </div>
-                                    <Separator className="bg-slate-300 w-[280px]" />{" "}
-                                </>
-                            )}
                             <Separator className="bg-slate-300 w-[280px]" />
                             <div className="flex flex-col items-center gap-2">
                                 <Label>Pastebin API Key</Label>
@@ -517,6 +490,19 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                                 </p>
                             </div>
                             <Separator className="bg-slate-300 w-[280px]" />
+                            <div className="flex flex-row items-center gap-2">
+                                <label className="text-2xl font-semibold font-poppins">
+                                    Animate map movements?
+                                </label>
+                                <Checkbox
+                                    checked={$animateMapMovements}
+                                    onCheckedChange={() => {
+                                        animateMapMovements.set(
+                                            !$animateMapMovements,
+                                        );
+                                    }}
+                                />
+                            </div>
                             <div className="flex flex-row items-center gap-2">
                                 <label className="text-2xl font-semibold font-poppins">
                                     Force Pastebin for sharing?

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -78,14 +78,6 @@ export const questionModified = (..._: any[]) => {
 export const leafletMapContext = atom<Map | null>(null);
 
 export const defaultUnit = persistentAtom<Units>("defaultUnit", "miles");
-export const highlightTrainLines = persistentAtom<boolean>(
-    "highlightTrainLines",
-    false,
-    {
-        encode: JSON.stringify,
-        decode: JSON.parse,
-    },
-);
 export const hiderMode = persistentAtom<
     | false
     | {
@@ -316,6 +308,9 @@ export const autoZoom = persistentAtom<boolean>("autoZoom", true, {
 
 export const isLoading = atom<boolean>(false);
 
+export const baseTileLayer = persistentAtom<
+    "voyager" | "light" | "dark" | "transport" | "neighbourhood" | "osmcarto"
+>("baseTileLayer", "voyager");
 export const thunderforestApiKey = persistentAtom<string>(
     "thunderforestApiKey",
     "",


### PR DESCRIPTION
This PR adds the ability to change the base map style and resolves #180.

This is done by:
- Replacing the existing boolean option `highlightTrainLines` by a `baseTileLayer` enum option;
- Selecting the appropriate TileLayer in a separate function in Map.tsx.

I've added the following styles: CARTO Voyager, CARTO Light, CARTO Dark, Thunderforest Transport, Thunderforest Neighbourhood, OpenStreetMap Carto.

CARTO Voyager is still the default, and fallback shown when a Thunderforest layer is selected without providing the api key. The previous behavior of "highlighting train lines" is replicated by selecting the "Thunderforest Transport" layer.

As a small change, I've moved the "Animate map movement" checkbox in the option drawer down with all of the other checkboxes; it looked weird to have a sequence of (separator - label - text/select input) broken up with a sole checkbox in the middle.