### PR TITLE
Handle Overpass failures

### DIFF
--- a/src/maps/api/overpass.ts
+++ b/src/maps/api/overpass.ts
@@ -2,6 +2,7 @@ import * as turf from "@turf/turf";
 import type { FeatureCollection, MultiPolygon } from "geojson";
 import _ from "lodash";
 import osmtogeojson from "osmtogeojson";
+import { toast } from "react-toastify";
 
 import {
     additionalMapGeoLocations,
@@ -30,6 +31,15 @@ export const getOverpassData = async (
         loadingText,
         cacheType,
     );
+
+    if (!response.ok) {
+        toast.error(
+            `Could not load data from Overpass: ${response.status} ${response.statusText}`,
+            { toastId: "overpass-error" },
+        );
+        return { elements: [] };
+    }
+
     const data = await response.json();
     return data;
 };


### PR DESCRIPTION
This PR fixes #175 in a pretty simple way - whenever Overpass returns a non-ok response an error toast is displayed, and a minimal `{ elements: [] }` object is returned. All code using Overpass continues to work as-if no features were identified.