### PR TITLE
"Default to custom questions" mode

### DIFF
--- a/src/components/AddQuestionDialog.tsx
+++ b/src/components/AddQuestionDialog.tsx
@@ -11,7 +11,12 @@ import {
     DialogTrigger,
 } from "@/components/ui/dialog";
 import { SidebarMenuButton } from "@/components/ui/sidebar-l";
-import { addQuestion, isLoading, leafletMapContext } from "@/lib/context";
+import {
+    addQuestion,
+    defaultCustomQuestions,
+    isLoading,
+    leafletMapContext,
+} from "@/lib/context";
 
 export const AddQuestionDialog = ({
     children,
@@ -59,7 +64,14 @@ export const AddQuestionDialog = ({
         const center = map.getCenter();
         addQuestion({
             id: "tentacles",
-            data: { lat: center.lat, lng: center.lng },
+            data: defaultCustomQuestions.get()
+                ? {
+                      lat: center.lat,
+                      lng: center.lng,
+                      locationType: "custom",
+                      places: [],
+                  }
+                : { lat: center.lat, lng: center.lng },
         });
         return true;
     };
@@ -70,7 +82,9 @@ export const AddQuestionDialog = ({
         const center = map.getCenter();
         addQuestion({
             id: "matching",
-            data: { lat: center.lat, lng: center.lng },
+            data: defaultCustomQuestions.get()
+                ? { lat: center.lat, lng: center.lng, type: "custom-points" }
+                : { lat: center.lat, lng: center.lng },
         });
         return true;
     };
@@ -81,7 +95,9 @@ export const AddQuestionDialog = ({
         const center = map.getCenter();
         addQuestion({
             id: "measuring",
-            data: { lat: center.lat, lng: center.lng },
+            data: defaultCustomQuestions.get()
+                ? { lat: center.lat, lng: center.lng, type: "custom-measure" }
+                : { lat: center.lat, lng: center.lng },
         });
         return true;
     };

--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -19,6 +19,7 @@ import {
     customInitPreference,
     customPresets,
     customStations,
+    defaultCustomQuestions,
     defaultUnit,
     disabledStations,
     displayHidingZonesOptions,
@@ -71,6 +72,7 @@ const PASTEBIN_URL_PARAM = "pb";
 
 export const OptionDrawers = ({ className }: { className?: string }) => {
     useStore(triggerLocalRefresh);
+    const $defaultCustomQuestions = useStore(defaultCustomQuestions);
     const $defaultUnit = useStore(defaultUnit);
     const $animateMapMovements = useStore(animateMapMovements);
     const $autoZoom = useStore(autoZoom);
@@ -574,6 +576,19 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                                     checked={$followMe}
                                     onCheckedChange={() =>
                                         followMe.set(!$followMe)
+                                    }
+                                />
+                            </div>
+                            <div className="flex flex-row items-center gap-2">
+                                <label className="text-2xl font-semibold font-poppins">
+                                    Default to custom questions?
+                                </label>
+                                <Checkbox
+                                    checked={$defaultCustomQuestions}
+                                    onCheckedChange={() =>
+                                        defaultCustomQuestions.set(
+                                            !$defaultCustomQuestions,
+                                        )
                                     }
                                 />
                             </div>

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -336,6 +336,14 @@ export const followMe = persistentAtom<boolean>("followMe", false, {
     encode: JSON.stringify,
     decode: JSON.parse,
 });
+export const defaultCustomQuestions = persistentAtom<boolean>(
+    "defaultCustomQuestions",
+    false,
+    {
+        encode: JSON.stringify,
+        decode: JSON.parse,
+    },
+);
 
 export const pastebinApiKey = persistentAtom<string>("pastebinApiKey", "");
 export const alwaysUsePastebin = persistentAtom<boolean>(


### PR DESCRIPTION
This PR adds a "Default to custom questions" options, which, when selected, will default the Tentacles, Measure and Match questions to be custom ones with empty feature sets.

I play the game with POI coordinates predefined, included as presets generated beforehand. This saves on a little bit of latency, especially with the tentacle question, which needs to re-run the Overpass query every time it's added. Without PR #207 there's also a possibility that an Overpass failure soft-locks the entire app.

I'm not sure if such mode would be useful to many other players, but since this is a relatively simple change might as well submit a PR.