### PR TITLE
fix: don't use cors proxy to read pastebin raw

### DIFF
--- a/src/maps/api/constants.ts
+++ b/src/maps/api/constants.ts
@@ -4,8 +4,7 @@ export const OVERPASS_API = "https://overpass-api.de/api/interpreter";
 export const GEOCODER_API = "https://photon.komoot.io/api/";
 export const PASTEBIN_API_POST_URL =
     "https://cors-anywhere.com/https://pastebin.com/api/api_post.php";
-export const PASTEBIN_API_RAW_URL =
-    "https://cors-anywhere.com/https://pastebin.com/raw/";
+export const PASTEBIN_API_RAW_URL = "https://pastebin.com/raw/";
 
 export const ICON_COLORS = {
     black: "#3D3D3D",


### PR DESCRIPTION
Pastebin's raw endpoint is not actually part of their API and so already supports CORS (it always sets the `Access-Control-Allow-Origin` header to `*`), so no proxy is required. This means significantly less probability of impact when the CORS proxy is down, as its usage is now restricted only to when posting to Pastebin (which should be relatively rare, compared to fetching information from a Paste).