### PR TITLE
Implement the "Admin Border Question" in the Measuring category

### DIFF
--- a/src/components/cards/measuring.tsx
+++ b/src/components/cards/measuring.tsx
@@ -1,6 +1,7 @@
 import { useStore } from "@nanostores/react";
 import { Label } from "@radix-ui/react-label";
 import * as React from "react";
+import { Suspense, use } from "react";
 
 import CustomInitDialog from "@/components/CustomInitDialog";
 import { LatitudeLongitude } from "@/components/LatLngPicker";
@@ -23,7 +24,10 @@ import {
     triggerLocalRefresh,
 } from "@/lib/context";
 import { cn } from "@/lib/utils";
-import { determineMeasuringBoundary } from "@/maps/questions/measuring";
+import {
+    determineMeasuringBoundary,
+    findAdminZoneInfo,
+} from "@/maps/questions/measuring";
 import {
     determineUnionizedStrings,
     type MeasuringQuestion,
@@ -63,6 +67,64 @@ export const MeasuringQuestionComponent = ({
     let questionSpecific = <></>;
 
     switch (data.type) {
+        case "admin-measure":
+            questionSpecific = (
+                <>
+                    <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
+                        <Select
+                            trigger="OSM Zone"
+                            options={{
+                                2: "OSM Zone 2 (Country)",
+                                3: "OSM Zone 3 (region in Japan)",
+                                4: "OSM Zone 4 (prefecture in Japan)",
+                                5: "OSM Zone 5",
+                                6: "OSM Zone 6",
+                                7: "OSM Zone 7",
+                                8: "OSM Zone 8",
+                                9: "OSM Zone 9",
+                                10: "OSM Zone 10",
+                            }}
+                            value={((data as any).cat?.adminLevel ?? 4).toString()}
+                            onValueChange={(value) => {
+                                if (!(data as any).cat) {
+                                    (data as any).cat = { adminLevel: 4 };
+                                }
+                                (data as any).cat.adminLevel = parseInt(
+                                    value,
+                                ) as 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+                                (data as any).cat.zoneName = undefined;
+                                questionModified();
+                            }}
+                            disabled={!data.drag || $isLoading}
+                        />
+                    </SidebarMenuItem>
+                    <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
+                        <Suspense
+                            fallback={
+                                <div className="flex items-center justify-center w-full h-[3rem]">
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        width="24"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        strokeWidth="2"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        className="animate-spin"
+                                    >
+                                        <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                                    </svg>
+                                </div>
+                            }
+                        >
+                            <AdminZoneNameDisplay data={data} />
+                        </Suspense>
+                    </SidebarMenuItem>
+                </>
+            );
+            break;
         case "mcdonalds":
         case "seven11":
             questionSpecific = (
@@ -250,6 +312,9 @@ export const MeasuringQuestionComponent = ({
                             questionModified();
                             return;
                         }
+                        if (value === "admin-measure" && !(data as any).cat) {
+                            (data as any).cat = { adminLevel: 4 };
+                        }
                         data.type = value;
                         questionModified();
                     }}
@@ -301,5 +366,47 @@ export const MeasuringQuestionComponent = ({
                 </ToggleGroup>
             </div>
         </QuestionCard>
+    );
+};
+
+const AdminZoneNameDisplay = ({
+    data,
+}: {
+    data: MeasuringQuestion;
+}) => {
+    useStore(triggerLocalRefresh);
+
+    const adminLevel = (data as any).cat?.adminLevel ?? 4;
+    const zoneInfo = use(
+        findAdminZoneInfo(data.lat, data.lng, adminLevel),
+    );
+
+    // Update the zone name in the data
+    if (
+        zoneInfo &&
+        (data as any).cat &&
+        (data as any).cat.zoneName !== zoneInfo.name
+    ) {
+        (data as any).cat.zoneName = zoneInfo.name;
+        questionModified();
+    }
+
+    if (!zoneInfo) {
+        return (
+            <div className="flex items-center justify-center w-full h-[3rem] text-muted-foreground text-sm">
+                No zone found
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col items-center w-full h-[3rem]">
+            <Label className="text-xs text-muted-foreground">
+                Zone
+            </Label>
+            <span className="font-medium text-sm truncate max-w-full">
+                {zoneInfo.name}
+            </span>
+        </div>
     );
 };

--- a/src/maps/questions/measuring.ts
+++ b/src/maps/questions/measuring.ts
@@ -13,6 +13,7 @@ import {
 } from "@/lib/context";
 import {
     fetchCoastline,
+    findAdminBoundary,
     findPlacesInZone,
     findPlacesSpecificInZone,
     LOCATION_FIRST_TAG,
@@ -32,6 +33,32 @@ import type {
     HomeGameMeasuringQuestions,
     MeasuringQuestion,
 } from "@/maps/schema";
+
+export interface AdminZoneInfo {
+    name: string;
+    boundary: any;
+}
+
+export const findAdminZoneInfo = _.memoize(
+    async (
+        lat: number,
+        lng: number,
+        adminLevel: 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10,
+    ): Promise<AdminZoneInfo | null> => {
+        const boundary = await findAdminBoundary(lat, lng, adminLevel);
+
+        if (!boundary) {
+            return null;
+        }
+
+        const name =
+            boundary.properties?.["name:en"] ?? boundary.properties?.name ?? "Unknown";
+
+        return { name, boundary };
+    },
+    (lat, lng, adminLevel) =>
+        `${lat.toFixed(6)},${lng.toFixed(6)},${adminLevel}`,
+);
 
 const highSpeedBase = _.memoize(
     (features: Feature[]) => {
@@ -99,6 +126,29 @@ export const determineMeasuringBoundary = async (
             ).features;
 
             return [highSpeedBase(features)];
+        }
+        case "admin-measure": {
+            const adminLevel = (question as any).cat?.adminLevel ?? 4;
+            const zoneInfo = await findAdminZoneInfo(
+                question.lat,
+                question.lng,
+                adminLevel,
+            );
+
+            if (!zoneInfo) {
+                toast.error("No admin boundary found at this location");
+                return [turf.multiPolygon([])];
+            }
+
+            // Store the zone name for display
+            if (!(question as any).cat) {
+                (question as any).cat = { adminLevel };
+            }
+            (question as any).cat.zoneName = zoneInfo.name;
+
+            // Convert the polygon to its outline (the border)
+            const outline = turf.polygonToLine(zoneInfo.boundary);
+            return [outline];
         }
         case "coastline": {
             const coastline = turf.lineToPolygon(
@@ -275,6 +325,7 @@ const bufferedDeterminer = _.memoize(
                 ? polyGeoJSON.get()
                 : mapGeoLocation.get(),
             geo: (question as any).geo,
+            cat: (question as any).cat,
         }),
 );
 

--- a/src/maps/schema.ts
+++ b/src/maps/schema.ts
@@ -334,6 +334,7 @@ const ordinaryMeasuringQuestionSchema = baseMeasuringQuestionSchema.extend({
             z
                 .literal("highspeed-measure-shinkansen")
                 .describe("High-Speed Rail Question"),
+            z.literal("admin-measure").describe("Admin Border Question"),
             z
                 .literal("aquarium-full")
                 .describe("Aquarium Question (Small+Medium Games)"),
@@ -367,6 +368,22 @@ const ordinaryMeasuringQuestionSchema = baseMeasuringQuestionSchema.extend({
                 .describe("Park Question (Small+Medium Games)"),
         ])
         .default("coastline"),
+    cat: z
+        .object({
+            adminLevel: z.union([
+                z.literal(2),
+                z.literal(3),
+                z.literal(4),
+                z.literal(5),
+                z.literal(6),
+                z.literal(7),
+                z.literal(8),
+                z.literal(9),
+                z.literal(10),
+            ]),
+            zoneName: z.string().optional(),
+        })
+        .optional(),
 });
 
 const hidingZoneMeasuringQuestionsSchema = baseMeasuringQuestionSchema.extend({


### PR DESCRIPTION
This PR implements the distance from the administrative border question. The name of the currently active OSM admin zone is displayed for easier communication with hiders.

Question requested in #9
