### PR TITLE
feat: add save file share and fix popover list scroll on mobile

### DIFF
--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -92,6 +92,7 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
     const lastDefaultUnit = useRef($defaultUnit);
     const hasSyncedInitialUnit = useRef(false);
     const [isOptionsOpen, setOptionsOpen] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
         const currentDefault = $defaultUnit;
@@ -276,13 +277,77 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
         }
     };
 
+    const saveToFile = () => {
+        try {
+            const data = JSON.stringify($hidingZone, null, 2);
+            const blob = new Blob([data], { type: "application/json" });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            const timestamp = new Date()
+                .toISOString()
+                .replace(/[:.]/g, "-")
+                .slice(0, 19);
+            a.download = `jetlag-hiding-zone-${timestamp}.json`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            toast.success("Hiding zone saved to file", { autoClose: 2000 });
+        } catch (e) {
+            console.error("Failed to save file:", e);
+            toast.error(`Failed to save file: ${e}`);
+        }
+    };
+
+    const loadFromFile = (file: File) => {
+        const reader = new FileReader();
+        reader.onload = (event) => {
+            const result = event.target?.result;
+            if (typeof result === "string") {
+                loadHidingZone(result);
+            } else {
+                toast.error("Failed to read file");
+            }
+        };
+        reader.onerror = () => {
+            toast.error("Failed to read file");
+        };
+        reader.readAsText(file);
+    };
+
     return (
         <div
             className={cn(
-                "flex justify-end gap-2 max-[412px]:!mb-4 max-[340px]:flex-col",
+                "flex justify-end gap-2 max-[412px]:!mb-4 max-[640px]:overflow-x-auto max-[640px]:w-[85vw] max-[640px]:justify-start max-[640px]:[&>button]:flex-shrink-0 max-[640px]:[&>div]:flex-shrink-0 max-[640px]:pb-1",
                 className,
             )}
         >
+            <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/json,.json"
+                className="hidden"
+                onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) loadFromFile(file);
+                    e.target.value = "";
+                }}
+            />
+            <Button
+                className="shadow-md"
+                onClick={saveToFile}
+                title="Download current hiding zone as a JSON file"
+            >
+                Save File
+            </Button>
+            <Button
+                className="shadow-md"
+                onClick={() => fileInputRef.current?.click()}
+                title="Load a hiding zone from a JSON file"
+            >
+                Load File
+            </Button>
             <Button
                 className="shadow-md"
                 onClick={async () => {
@@ -300,30 +365,35 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                     let shareUrl = `${baseUrl}?${HIDING_ZONE_COMPRESSED_URL_PARAM}=${compressedData}`;
 
                     if ($alwaysUsePastebin || shareUrl.length > 2000) {
-                        if (!$pastebinApiKey) {
-                            toast.error(
-                                "Data is too large for a URL or Pastebin is forced. Please enter a Pastebin API key in Options to share via Pastebin.",
+                        if ($pastebinApiKey) {
+                            try {
+                                toast.info(
+                                    "Data is being shared via Pastebin...",
+                                );
+                                const pastebinUrl = await uploadToPastebin(
+                                    $pastebinApiKey,
+                                    hidingZoneString,
+                                );
+                                const pasteId = pastebinUrl.substring(
+                                    pastebinUrl.lastIndexOf("/") + 1,
+                                );
+                                shareUrl = `${baseUrl}?${PASTEBIN_URL_PARAM}=${pasteId}`;
+                                toast.success(
+                                    "Successfully uploaded to Pastebin! URL is ready to be shared.",
+                                );
+                            } catch (error) {
+                                console.error("Pastebin upload failed:", error);
+                                toast.warning(
+                                    "Pastebin upload failed, falling back to file download.",
+                                );
+                                saveToFile();
+                                return;
+                            }
+                        } else {
+                            toast.info(
+                                "Data is too large for a URL — saving to file instead.",
                             );
-                            return;
-                        }
-                        try {
-                            toast.info("Data is being shared via Pastebin...");
-                            const pastebinUrl = await uploadToPastebin(
-                                $pastebinApiKey,
-                                hidingZoneString,
-                            );
-                            const pasteId = pastebinUrl.substring(
-                                pastebinUrl.lastIndexOf("/") + 1,
-                            );
-                            shareUrl = `${baseUrl}?${PASTEBIN_URL_PARAM}=${pasteId}`;
-                            toast.success(
-                                "Successfully uploaded to Pastebin! URL is ready to be shared.",
-                            );
-                        } catch (error) {
-                            console.error("Pastebin upload failed:", error);
-                            toast.error(
-                                `Pastebin upload failed. Please check your API key and try again.`,
-                            );
+                            saveToFile();
                             return;
                         }
                     }
@@ -487,8 +557,9 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                                     placeholder="Enter your Pastebin API key"
                                 />
                                 <p className="text-xs text-gray-500">
-                                    Needed for sharing large game data. Create a
-                                    key{" "}
+                                    Optional. If set, large game data will be
+                                    shared via Pastebin URL; otherwise it falls
+                                    back to a JSON file download. Create a key{" "}
                                     <a
                                         href="https://pastebin.com/doc_api"
                                         target="_blank"

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,225 +1,183 @@
-import * as SelectPrimitive from "@radix-ui/react-select";
-import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { Check, ChevronDown } from "lucide-react";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
 type Options<T extends string> = Partial<Record<T, string>>;
+
 const Select = <T extends string>({
     trigger,
     options,
     groups,
-    ...rest
+    value,
+    onValueChange,
+    disabled,
 }: {
     disabled?: boolean;
     trigger: string | Record<"className" | "placeholder", string>;
     options?: Options<T>;
     groups?: Record<
         string,
-        { disabled: boolean; options: Options<T> } | Options<T>
+        { disabled?: boolean; options: Options<T> } | Options<T>
     >;
     onValueChange?: (value: T) => void;
     value: T;
 }) => {
     const { placeholder, className } =
-        typeof trigger == "string" ? { placeholder: trigger } : trigger;
-    const mapObj = <T,>(
-        obj: Partial<Record<string, T>>,
-        fn: (key: string, value: T) => React.ReactNode,
-    ) => Object.entries(obj).map(([k, v]) => fn(k, v!));
-    const Options = ({
-        options,
-        ...rest
-    }: {
-        options: Options<T>;
-        disabled?: boolean;
-    }) =>
-        mapObj(options, (value, children) => (
-            <SelectItem key={value} {...{ ...rest, value, children }} />
-        ));
+        typeof trigger === "string" ? { placeholder: trigger, className: "" } : trigger;
+    const [open, setOpen] = React.useState(false);
+    const triggerRef = React.useRef<HTMLButtonElement>(null);
+    const [triggerWidth, setTriggerWidth] = React.useState<number | undefined>(
+        undefined,
+    );
+
+    React.useLayoutEffect(() => {
+        if (open && triggerRef.current) {
+            setTriggerWidth(triggerRef.current.offsetWidth);
+        }
+    }, [open]);
+
+    const flatOptions: Options<T> = React.useMemo(() => {
+        const merged: Options<T> = { ...(options ?? {}) };
+        if (groups) {
+            for (const v of Object.values(groups)) {
+                const opts =
+                    v && typeof v === "object" && "options" in v
+                        ? v.options
+                        : (v as Options<T>);
+                Object.assign(merged, opts);
+            }
+        }
+        return merged;
+    }, [options, groups]);
+
+    const displayValue = flatOptions[value];
+
+    const handleSelect = (next: T) => {
+        onValueChange?.(next);
+        setOpen(false);
+    };
+
     return (
-        <SelectPrimitive.Root {...rest}>
-            <SelectTrigger {...{ className }}>
-                <SelectValue {...{ placeholder }} />
-            </SelectTrigger>
-            <SelectContent>
-                {options && <Options {...{ options }} />}
-                {groups &&
-                    mapObj(groups, (children, optionsOrConfig) => {
-                        return (
-                            <SelectGroup key={children}>
-                                <SelectLabel {...{ children }} />
-                                <Options
-                                    {...("options" in optionsOrConfig &&
-                                    typeof optionsOrConfig.options == "object"
-                                        ? optionsOrConfig
-                                        : {
-                                              options:
-                                                  optionsOrConfig as Record<
-                                                      T,
-                                                      string
-                                                  >,
-                                          })}
-                                />
-                            </SelectGroup>
-                        );
-                    })}
-            </SelectContent>
-        </SelectPrimitive.Root>
+        <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
+            <PopoverPrimitive.Trigger
+                ref={triggerRef}
+                disabled={disabled}
+                className={cn(
+                    "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+                    className,
+                )}
+            >
+                <span
+                    className={cn(
+                        "line-clamp-1 text-left",
+                        !displayValue && "text-muted-foreground",
+                    )}
+                >
+                    {displayValue ?? placeholder}
+                </span>
+                <ChevronDown className="h-4 w-4 opacity-50 shrink-0 ml-2" />
+            </PopoverPrimitive.Trigger>
+                <PopoverPrimitive.Content
+                    align="start"
+                    sideOffset={4}
+                    style={{
+                        width: triggerWidth ? `${triggerWidth}px` : undefined,
+                        minWidth: "8rem",
+                    }}
+                    className={cn(
+                        "z-[1050] rounded-md border bg-popover text-popover-foreground shadow-md",
+                        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+                        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+                    )}
+                >
+                    <div
+                        className="p-1"
+                        style={{
+                            maxHeight: "24rem",
+                            overflowY: "auto",
+                            overscrollBehavior: "contain",
+                            touchAction: "pan-y",
+                            WebkitOverflowScrolling: "touch",
+                        }}
+                    >
+                        {options &&
+                            Object.entries(options).map(([k, label]) => (
+                                <SelectItem
+                                    key={k}
+                                    selected={k === value}
+                                    onSelect={() => handleSelect(k as T)}
+                                >
+                                    {label as string}
+                                </SelectItem>
+                            ))}
+                        {groups &&
+                            Object.entries(groups).map(([label, v]) => {
+                                const opts =
+                                    v && typeof v === "object" && "options" in v
+                                        ? v.options
+                                        : (v as Options<T>);
+                                const groupDisabled =
+                                    v &&
+                                    typeof v === "object" &&
+                                    "disabled" in v
+                                        ? !!v.disabled
+                                        : false;
+                                return (
+                                    <div key={label}>
+                                        <div className="py-1.5 pl-8 pr-2 text-sm font-semibold">
+                                            {label}
+                                        </div>
+                                        {Object.entries(opts).map(
+                                            ([k, itemLabel]) => (
+                                                <SelectItem
+                                                    key={k}
+                                                    selected={k === value}
+                                                    disabled={groupDisabled}
+                                                    onSelect={() =>
+                                                        handleSelect(k as T)
+                                                    }
+                                                >
+                                                    {itemLabel as string}
+                                                </SelectItem>
+                                            ),
+                                        )}
+                                    </div>
+                                );
+                            })}
+                    </div>
+                </PopoverPrimitive.Content>
+        </PopoverPrimitive.Root>
     );
 };
 
-const SelectGroup = SelectPrimitive.Group;
-
-const SelectValue = SelectPrimitive.Value;
-
-const SelectTrigger = React.forwardRef<
-    React.ElementRef<typeof SelectPrimitive.Trigger>,
-    React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-    <SelectPrimitive.Trigger
-        ref={ref}
-        className={cn(
-            "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
-            className,
-        )}
-        {...props}
-    >
-        {children}
-        <SelectPrimitive.Icon asChild>
-            <ChevronDown className="h-4 w-4 opacity-50" />
-        </SelectPrimitive.Icon>
-    </SelectPrimitive.Trigger>
-));
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
-
-const SelectScrollUpButton = React.forwardRef<
-    React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
-    React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
->(({ className, ...props }, ref) => (
-    <SelectPrimitive.ScrollUpButton
-        ref={ref}
-        className={cn(
-            "flex cursor-default items-center justify-center py-1",
-            className,
-        )}
-        {...props}
-    >
-        <ChevronUp className="h-4 w-4" />
-    </SelectPrimitive.ScrollUpButton>
-));
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
-
-const SelectScrollDownButton = React.forwardRef<
-    React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
-    React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
->(({ className, ...props }, ref) => (
-    <SelectPrimitive.ScrollDownButton
-        ref={ref}
-        className={cn(
-            "flex cursor-default items-center justify-center py-1",
-            className,
-        )}
-        {...props}
-    >
-        <ChevronDown className="h-4 w-4" />
-    </SelectPrimitive.ScrollDownButton>
-));
-SelectScrollDownButton.displayName =
-    SelectPrimitive.ScrollDownButton.displayName;
-
-const SelectContent = React.forwardRef<
-    React.ElementRef<typeof SelectPrimitive.Content>,
-    React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
-    <SelectPrimitive.Portal
-        container={document.querySelector(
-            "#map-modal-dialog-container-leaflet",
-        )}
-    >
-        <SelectPrimitive.Content
-            ref={ref}
+const SelectItem = ({
+    selected,
+    disabled,
+    onSelect,
+    children,
+}: {
+    selected?: boolean;
+    disabled?: boolean;
+    onSelect: () => void;
+    children: React.ReactNode;
+}) => {
+    return (
+        <button
+            type="button"
+            disabled={disabled}
+            onClick={onSelect}
             className={cn(
-                "relative z-[1050] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-                position === "popper" &&
-                    "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-                className,
+                "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none text-left hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50",
             )}
-            position={position}
-            {...props}
         >
-            <SelectScrollUpButton />
-            <SelectPrimitive.Viewport
-                className={cn(
-                    "p-1",
-                    position === "popper" &&
-                        "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
-                )}
-            >
-                {children}
-            </SelectPrimitive.Viewport>
-            <SelectScrollDownButton />
-        </SelectPrimitive.Content>
-    </SelectPrimitive.Portal>
-));
-SelectContent.displayName = SelectPrimitive.Content.displayName;
-
-const SelectLabel = React.forwardRef<
-    React.ElementRef<typeof SelectPrimitive.Label>,
-    React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
-    <SelectPrimitive.Label
-        ref={ref}
-        className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
-        {...props}
-    />
-));
-SelectLabel.displayName = SelectPrimitive.Label.displayName;
-
-const SelectItem = React.forwardRef<
-    React.ElementRef<typeof SelectPrimitive.Item>,
-    React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
-    <SelectPrimitive.Item
-        ref={ref}
-        className={cn(
-            "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-            className,
-        )}
-        {...props}
-    >
-        <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-            <SelectPrimitive.ItemIndicator>
-                <Check className="h-4 w-4" />
-            </SelectPrimitive.ItemIndicator>
-        </span>
-
-        <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-    </SelectPrimitive.Item>
-));
-SelectItem.displayName = SelectPrimitive.Item.displayName;
-
-const SelectSeparator = React.forwardRef<
-    React.ElementRef<typeof SelectPrimitive.Separator>,
-    React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
-    <SelectPrimitive.Separator
-        ref={ref}
-        className={cn("-mx-1 my-1 h-px bg-muted", className)}
-        {...props}
-    />
-));
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
-
-export {
-    Select,
-    SelectContent,
-    SelectGroup,
-    SelectItem,
-    SelectLabel,
-    SelectScrollDownButton,
-    SelectScrollUpButton,
-    SelectSeparator,
-    SelectTrigger,
-    SelectValue,
+            <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+                {selected && <Check className="h-4 w-4" />}
+            </span>
+            <span className="line-clamp-1">{children}</span>
+        </button>
+    );
 };
+
+export { Select };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,10 +1,29 @@
 import * as PopoverPrimitive from "@radix-ui/react-popover";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
 type Options<T extends string> = Partial<Record<T, string>>;
+
+const AUTO_SCROLL_INTERVAL_MS = 50;
+const FALLBACK_SCROLL_STEP_PX = 32;
+
+// Hover-capable pointer = desktop/laptop. Touch devices scroll natively and
+// cannot hover, so the scroll arrows are pointless there.
+const useCanHover = () => {
+    const [canHover, setCanHover] = React.useState(false);
+
+    React.useEffect(() => {
+        const mql = window.matchMedia("(hover: hover) and (pointer: fine)");
+        const onChange = () => setCanHover(mql.matches);
+        mql.addEventListener("change", onChange);
+        setCanHover(mql.matches);
+        return () => mql.removeEventListener("change", onChange);
+    }, []);
+
+    return canHover;
+};
 
 const Select = <T extends string>({
     trigger,
@@ -25,18 +44,79 @@ const Select = <T extends string>({
     value: T;
 }) => {
     const { placeholder, className } =
-        typeof trigger === "string" ? { placeholder: trigger, className: "" } : trigger;
+        typeof trigger === "string"
+            ? { placeholder: trigger, className: "" }
+            : trigger;
     const [open, setOpen] = React.useState(false);
     const triggerRef = React.useRef<HTMLButtonElement>(null);
     const [triggerWidth, setTriggerWidth] = React.useState<number | undefined>(
         undefined,
     );
 
+    const canHover = useCanHover();
+    const viewportRef = React.useRef<HTMLDivElement | null>(null);
+    const autoScrollTimerRef = React.useRef<number | null>(null);
+    const [canScrollUp, setCanScrollUp] = React.useState(false);
+    const [canScrollDown, setCanScrollDown] = React.useState(false);
+
     React.useLayoutEffect(() => {
         if (open && triggerRef.current) {
             setTriggerWidth(triggerRef.current.offsetWidth);
         }
     }, [open]);
+
+    const updateScrollButtons = React.useCallback(() => {
+        const viewport = viewportRef.current;
+        if (!viewport) return;
+        setCanScrollUp(viewport.scrollTop > 0);
+        setCanScrollDown(
+            viewport.scrollTop + viewport.clientHeight <
+                viewport.scrollHeight - 1,
+        );
+    }, []);
+
+    const viewportRefCallback = React.useCallback(
+        (node: HTMLDivElement | null) => {
+            viewportRef.current = node;
+            if (node) updateScrollButtons();
+        },
+        [updateScrollButtons],
+    );
+
+    const stopAutoScroll = React.useCallback(() => {
+        if (autoScrollTimerRef.current !== null) {
+            window.clearInterval(autoScrollTimerRef.current);
+            autoScrollTimerRef.current = null;
+        }
+    }, []);
+
+    // Mirrors Radix Select's scroll buttons: while hovered, scroll by one
+    // item height every 50ms. Stops at the edge, since the button then
+    // unmounts and no pointerleave is fired.
+    const startAutoScroll = React.useCallback(
+        (direction: -1 | 1) => {
+            if (autoScrollTimerRef.current !== null) return;
+            autoScrollTimerRef.current = window.setInterval(() => {
+                const viewport = viewportRef.current;
+                if (!viewport) {
+                    stopAutoScroll();
+                    return;
+                }
+                const step =
+                    viewport.querySelector("button")?.offsetHeight ||
+                    FALLBACK_SCROLL_STEP_PX;
+                const previous = viewport.scrollTop;
+                viewport.scrollTop = previous + direction * step;
+                if (viewport.scrollTop === previous) stopAutoScroll();
+            }, AUTO_SCROLL_INTERVAL_MS);
+        },
+        [stopAutoScroll],
+    );
+
+    React.useEffect(() => {
+        if (!open) stopAutoScroll();
+        return stopAutoScroll;
+    }, [open, stopAutoScroll]);
 
     const flatOptions: Options<T> = React.useMemo(() => {
         const merged: Options<T> = { ...(options ?? {}) };
@@ -79,76 +159,113 @@ const Select = <T extends string>({
                 </span>
                 <ChevronDown className="h-4 w-4 opacity-50 shrink-0 ml-2" />
             </PopoverPrimitive.Trigger>
-                <PopoverPrimitive.Content
-                    align="start"
-                    sideOffset={4}
+            <PopoverPrimitive.Content
+                align="start"
+                sideOffset={4}
+                style={{
+                    width: triggerWidth ? `${triggerWidth}px` : undefined,
+                    minWidth: "8rem",
+                    maxHeight: "24rem",
+                }}
+                className={cn(
+                    "z-[1050] flex flex-col rounded-md border bg-popover text-popover-foreground shadow-md",
+                    "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+                    "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+                )}
+            >
+                {canHover && canScrollUp && (
+                    <SelectScrollButton
+                        direction="up"
+                        onAutoScrollStart={() => startAutoScroll(-1)}
+                        onAutoScrollStop={stopAutoScroll}
+                    />
+                )}
+                <div
+                    ref={viewportRefCallback}
+                    onScroll={canHover ? updateScrollButtons : undefined}
+                    className="p-1"
                     style={{
-                        width: triggerWidth ? `${triggerWidth}px` : undefined,
-                        minWidth: "8rem",
+                        overflowY: "auto",
+                        overscrollBehavior: "contain",
+                        touchAction: "pan-y",
+                        WebkitOverflowScrolling: "touch",
                     }}
-                    className={cn(
-                        "z-[1050] rounded-md border bg-popover text-popover-foreground shadow-md",
-                        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
-                        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-                    )}
                 >
-                    <div
-                        className="p-1"
-                        style={{
-                            maxHeight: "24rem",
-                            overflowY: "auto",
-                            overscrollBehavior: "contain",
-                            touchAction: "pan-y",
-                            WebkitOverflowScrolling: "touch",
-                        }}
-                    >
-                        {options &&
-                            Object.entries(options).map(([k, label]) => (
-                                <SelectItem
-                                    key={k}
-                                    selected={k === value}
-                                    onSelect={() => handleSelect(k as T)}
-                                >
-                                    {label as string}
-                                </SelectItem>
-                            ))}
-                        {groups &&
-                            Object.entries(groups).map(([label, v]) => {
-                                const opts =
-                                    v && typeof v === "object" && "options" in v
-                                        ? v.options
-                                        : (v as Options<T>);
-                                const groupDisabled =
-                                    v &&
-                                    typeof v === "object" &&
-                                    "disabled" in v
-                                        ? !!v.disabled
-                                        : false;
-                                return (
-                                    <div key={label}>
-                                        <div className="py-1.5 pl-8 pr-2 text-sm font-semibold">
-                                            {label}
-                                        </div>
-                                        {Object.entries(opts).map(
-                                            ([k, itemLabel]) => (
-                                                <SelectItem
-                                                    key={k}
-                                                    selected={k === value}
-                                                    disabled={groupDisabled}
-                                                    onSelect={() =>
-                                                        handleSelect(k as T)
-                                                    }
-                                                >
-                                                    {itemLabel as string}
-                                                </SelectItem>
-                                            ),
-                                        )}
+                    {options &&
+                        Object.entries(options).map(([k, label]) => (
+                            <SelectItem
+                                key={k}
+                                selected={k === value}
+                                onSelect={() => handleSelect(k as T)}
+                            >
+                                {label as string}
+                            </SelectItem>
+                        ))}
+                    {groups &&
+                        Object.entries(groups).map(([label, v]) => {
+                            const opts =
+                                v && typeof v === "object" && "options" in v
+                                    ? v.options
+                                    : (v as Options<T>);
+                            const groupDisabled =
+                                v && typeof v === "object" && "disabled" in v
+                                    ? !!v.disabled
+                                    : false;
+                            return (
+                                <div key={label}>
+                                    <div className="py-1.5 pl-8 pr-2 text-sm font-semibold">
+                                        {label}
                                     </div>
-                                );
-                            })}
-                    </div>
-                </PopoverPrimitive.Content>
+                                    {Object.entries(opts).map(
+                                        ([k, itemLabel]) => (
+                                            <SelectItem
+                                                key={k}
+                                                selected={k === value}
+                                                disabled={groupDisabled}
+                                                onSelect={() =>
+                                                    handleSelect(k as T)
+                                                }
+                                            >
+                                                {itemLabel as string}
+                                            </SelectItem>
+                                        ),
+                                    )}
+                                </div>
+                            );
+                        })}
+                </div>
+                {canHover && canScrollDown && (
+                    <SelectScrollButton
+                        direction="down"
+                        onAutoScrollStart={() => startAutoScroll(1)}
+                        onAutoScrollStop={stopAutoScroll}
+                    />
+                )}
+            </PopoverPrimitive.Content>
         </PopoverPrimitive.Root>
+    );
+};
+
+const SelectScrollButton = ({
+    direction,
+    onAutoScrollStart,
+    onAutoScrollStop,
+}: {
+    direction: "up" | "down";
+    onAutoScrollStart: () => void;
+    onAutoScrollStop: () => void;
+}) => {
+    const Chevron = direction === "up" ? ChevronUp : ChevronDown;
+    return (
+        <div
+            aria-hidden="true"
+            className="flex shrink-0 cursor-default items-center justify-center py-1"
+            onPointerDown={onAutoScrollStart}
+            onPointerMove={onAutoScrollStart}
+            onPointerLeave={onAutoScrollStop}
+        >
+            <Chevron className="h-4 w-4" />
+        </div>
     );
 };
 


### PR DESCRIPTION
### Code was written by Claude Opus 4.7. Please let me know if it's not ok with you.

PR conmtents:

---

Since pastebin share not working for long (#169):  

**feat: add Save File and Load File buttons to quick access**

Pastebin API key is now optional. When data is too large for a URL, the Share button automatically saves to a JSON file instead of erroring out. If a Pastebin key is set but the upload fails, it also falls back to file download.

Mobile button row is now scrollable sideways and width changed to 85vw.
  
---

Since popover scroll is not responding on touch and only scrolls on arrow button click on mobile:

**fix: rebuild Select on top of Popover for native scroll**

Radix's Select intercepts pointer events on items and uses a DismissableLayer that disables outside pointer events on body, which together broke drag-to-scroll on touch even with all the CSS workarounds.

Replace the internals with @radix-ui/react-popover plus a plain scrollable div and button items. The same {trigger, options, groups, value, onValueChange, disabled} API is preserved so all call sites work unchanged. Native overflow scroll now works on touch and desktop without any item-selection conflicts.

The mobile sidebar wraps content in a Sheet/Dialog which uses react-remove-scroll. That library globally listens to touchmove on document and calls preventDefault on any touch outside its allowed region (the dialog content). When the popover was portal'd out to map-modal-dialog-container-leaflet, it sat outside that allowed region, so all touchmove events on it were cancelled — that's why drag-to-scroll never worked on Android Chrome.

Drop the portal so the popover renders inline as a child of the dialog content. react-remove-scroll then sees the touchmove as happening inside its tree and does not block it.

---

You can view/test changes at https://whitebrim.github.io/JetLagHideAndSeek/