### PR TITLE
style: change station icons to simple green blobs

### DIFF
--- a/src/components/ZoneSidebar.tsx
+++ b/src/components/ZoneSidebar.tsx
@@ -147,7 +147,11 @@ export const ZoneSidebar = () => {
             pointToLayer(geoJsonPoint, latlng) {
                 const marker = L.marker(latlng, {
                     icon: L.divIcon({
-                        html: `<div class="text-black bg-opacity-0"><svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 448 512" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg"><path d="M96 0C43 0 0 43 0 96L0 352c0 48 35.2 87.7 81.1 94.9l-46 46C28.1 499.9 33.1 512 43 512l39.7 0c8.5 0 16.6-3.4 22.6-9.4L160 448l128 0 54.6 54.6c6 6 14.1 9.4 22.6 9.4l39.7 0c10 0 15-12.1 7.9-19.1l-46-46c46-7.1 81.1-46.9 81.1-94.9l0-256c0-53-43-96-96-96L96 0zM64 96c0-17.7 14.3-32 32-32l256 0c17.7 0 32 14.3 32 32l0 96c0 17.7-14.3 32-32 32L96 224c-17.7 0-32-14.3-32-32l0-96zM224 288a48 48 0 1 1 0 96 48 48 0 1 1 0-96z"></path></svg></div>`,
+                        html: `<div class="text-black bg-opacity-0"><svg width="1em" height="1em" stroke="currentColor" stroke-width="0" version="1.1" viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg">
+ <circle cx="250" cy="250" r="250" fill="green" fill-opacity=".1"/>
+ <circle cx="250" cy="250" r="175" fill="green" fill-opacity=".7" stroke-width="0"/>
+</svg>
+</div>`,
                         className: "",
                     }),
                 });


### PR DESCRIPTION
This PR changes station icons (with _Display hiding zones?_ enabled and set to _All Stations_) from a rail icon to a generic green blob (matching color with the _All Zones_ circles). The rail icon has poor contrast, is very noisy on the eye, and looks pretty bad in dense areas with multiple stations close to each other, and obstructs the map quite significantly. The green circle solves most of those problems (maybe apart from the contrast), while still conveying the meaning of a station.

|  | After | Before |
|---|---|---|
| Zoomed Out | <img height="1000" alt="after-far" src="https://github.com/user-attachments/assets/dbbad062-bbdd-491e-ad5d-b7787fe2d915" /> | <img height="1000" alt="before-far" src="https://github.com/user-attachments/assets/12ce78d7-dd6f-4e62-9121-a4cbaf98878b" /> |
| Zoomed In | <img height="1000" alt="after-close" src="https://github.com/user-attachments/assets/ec0d8b03-710c-4ed1-9155-50c29c1528d1" /> | <img height="1000" alt="before-close" src="https://github.com/user-attachments/assets/99ef161c-1310-40de-ae82-d1250f02a4c0" /> |

