### PR TITLE
feat: load hiding zone from a url

### DIFF
--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -74,6 +74,7 @@ import { UnitSelect } from "./UnitSelect";
 const HIDING_ZONE_URL_PARAM = "hz";
 const HIDING_ZONE_COMPRESSED_URL_PARAM = "hzc";
 const PASTEBIN_URL_PARAM = "pb";
+const FETCH_URL_PARAM = "url";
 
 export const OptionDrawers = ({ className }: { className?: string }) => {
     useStore(triggerLocalRefresh);
@@ -120,6 +121,7 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
             HIDING_ZONE_COMPRESSED_URL_PARAM,
         );
         const pastebinId = params.get(PASTEBIN_URL_PARAM);
+        const fetchUrl = params.get(FETCH_URL_PARAM);
 
         if (hidingZoneOld !== null) {
             // Legacy base64 encoding
@@ -167,6 +169,35 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                     console.error("Failed to fetch from Pastebin:", error);
                     toast.error(
                         `Failed to load from Pastebin: ${error.message}`,
+                    );
+                });
+        } else if (fetchUrl !== null) {
+            fetch(fetchUrl)
+                .then((response) => {
+                    if (!response.ok)
+                        throw `${response.status} ${response.statusText}`;
+                    return response.text();
+                })
+                .then((data) => {
+                    try {
+                        loadHidingZone(data);
+                        // Remove url parameter after initial load
+                        window.history.replaceState(
+                            {},
+                            "",
+                            window.location.pathname,
+                        );
+                        toast.success(
+                            `Successfully loaded data from ${fetchUrl}`,
+                        );
+                    } catch (e) {
+                        toast.error(`Invalid data from ${fetchUrl}: ${e}`);
+                    }
+                })
+                .catch((error) => {
+                    console.error(`Failed to fetch from ${fetchUrl}:`, error);
+                    toast.error(
+                        `Failed to load from ${fetchUrl}: ${error.message}`,
                     );
                 });
         }


### PR DESCRIPTION
This PR allows users to load a hiding zone JSON file by providing a `url` search parameter, for example `https://taibeled.github.io/JetLagHideAndSeek/?url=https://mkuran.pl/other/hs/gzm/taibeled.min.json`. Pastebin's 512 KiB file size restriction can be quite limiting for presets which include a lot of borders and can't realistically be reduced down without weird aggressive linestring simplification.

I have not added any CORS workarounds, my expectation is that whoever shares presets has set up an appropriate Access-Control-Allow-Origin header in responses. However, if that is a problem; or someone wants to host the preset on something like https://gist.github.com, the full URL can be provided as `https://taibeled.github.io/JetLagHideAndSeek/?url=https://corsproxy.io/%3Furl=https://mkuran.pl/other/hs/warsaw/game.json`.