### PR TITLE
Fetch places from the API and add five question types

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,20 @@ A great deal of appreciation goes out to these individuals who have helped to cr
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+
+### Geodata API
+
+The API provides POI and high-speed rail data. It also adds five new questions:
+elevation, nearest body of water, landmass, motorways, and nearest street or path.
+The browser still calculates the answers. Airports continue to use Overpass
+because the API defines airports differently.
+
+Existing POI and high-speed rail lookups fall back to Overpass if the API is
+unavailable. You can also select “Use original Overpass data?” in Options.
+
+To use another API with the same endpoints and response format, change
+`PUBLIC_JETLAG_GEODATA_API` and allow the app's origin on that server.
+
+For large areas, results are automatically limited to major motorways and
+prominent parks for those questions. Some geometry is approximate, and results
+can differ from Overpass.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ elevation, nearest body of water, landmass, motorways, and nearest street or pat
 The browser still calculates the answers. Airports continue to use Overpass
 because the API defines airports differently.
 
+New players use the API by default. Returning players keep Overpass and get a
+one-time prompt to switch.
+
 Existing POI and high-speed rail lookups fall back to Overpass if the API is
 unavailable. You can also select “Use original Overpass data?” in Options.
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,10 @@ import { defineConfig } from "astro/config";
 
 // https://astro.build/config
 export default defineConfig({
+    vite: {
+        worker: { format: "es" },
+        resolve: { alias: { "@": new URL("./src", import.meta.url).pathname } },
+    },
     integrations: [
         react(),
         tailwind({

--- a/src/components/DataSourceDialog.tsx
+++ b/src/components/DataSourceDialog.tsx
@@ -1,0 +1,52 @@
+import { useStore } from "@nanostores/react";
+
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+    dataSourcePromptDismissed,
+    showTutorial,
+    useLegacyDataSources,
+} from "@/lib/context";
+
+export const DataSourceDialog = () => {
+    const dismissed = useStore(dataSourcePromptDismissed);
+    const tutorial = useStore(showTutorial);
+    const chooseSource = (legacy: boolean) => {
+        useLegacyDataSources.set(legacy);
+        dataSourcePromptDismissed.set(true);
+    };
+
+    return (
+        <AlertDialog open={!dismissed && !tutorial}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>
+                        Try the new data source?
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                        The new API provides POI and high-speed rail data.
+                        Results can differ from Overpass, so keep Overpass if
+                        you are in the middle of a game. You can change this
+                        later in Options.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel onClick={() => chooseSource(true)}>
+                        Keep Overpass
+                    </AlertDialogCancel>
+                    <AlertDialogAction onClick={() => chooseSource(false)}>
+                        Use the API
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+};

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -29,10 +29,12 @@ import {
     thunderforestApiKey,
     triggerLocalRefresh,
 } from "@/lib/context";
+import { withMapProgress } from "@/lib/mapProgress";
 import { cn } from "@/lib/utils";
 import { applyQuestionsToMapGeoData, holedMask } from "@/maps";
 import { hiderifyQuestion } from "@/maps";
 import { clearCache, determineMapBoundaries } from "@/maps/api";
+import { maskMap } from "@/maps/geo-utils/geometryWorker";
 
 import { DraggableMarkers } from "./DraggableMarkers";
 import { LeafletFullScreenButton } from "./LeafletFullScreenButton";
@@ -122,7 +124,6 @@ export const Map = ({ className }: { className?: string }) => {
     const $baseTileLayer = useStore(baseTileLayer);
     const $thunderforestApiKey = useStore(thunderforestApiKey);
     const $hiderMode = useStore(hiderMode);
-    const $isLoading = useStore(isLoading);
     const $followMe = useStore(followMe);
     const $permanentOverlay = useStore(permanentOverlay);
     const map = useStore(leafletMapContext);
@@ -136,10 +137,8 @@ export const Map = ({ className }: { className?: string }) => {
         [],
     );
 
-    const refreshQuestions = async (focus: boolean = false) => {
+    const calculateQuestions = async (focus: boolean = false) => {
         if (!map) return;
-
-        if ($isLoading) return;
 
         isLoading.set(true);
 
@@ -170,8 +169,22 @@ export const Map = ({ className }: { className?: string }) => {
         }
 
         if ($hiderMode !== false) {
-            for (const question of $questions) {
-                await hiderifyQuestion(question);
+            try {
+                for (const question of $questions) {
+                    if (
+                        question.id === "measuring" &&
+                        question.data.type === "motorway"
+                    )
+                        continue;
+                    await hiderifyQuestion(question);
+                }
+            } catch (error) {
+                toast.error(
+                    error instanceof Error
+                        ? error.message
+                        : "Could not determine the hider's answer.",
+                );
+                return;
             }
 
             triggerLocalRefresh.set(Math.random()); // Refresh the question sidebar with new information but not this map
@@ -184,11 +197,13 @@ export const Map = ({ className }: { className?: string }) => {
         });
 
         try {
+            const planningBounds: number[][] = [];
             mapGeoData = await applyQuestionsToMapGeoData(
                 $questions,
                 mapGeoData,
                 planningModeEnabled.get(),
                 (geoJSONObj, question) => {
+                    planningBounds.push(turf.bbox(geoJSONObj));
                     const geoJSONPlane = L.geoJSON(geoJSONObj);
                     // @ts-expect-error This is a check such that only this type of layer is removed
                     geoJSONPlane.questionKey = question.key;
@@ -196,9 +211,22 @@ export const Map = ({ className }: { className?: string }) => {
                 },
             );
 
+            const remainingBounds = planningBounds.length
+                ? [
+                      Math.min(...planningBounds.map((box) => box[0])),
+                      Math.min(...planningBounds.map((box) => box[1])),
+                      Math.max(...planningBounds.map((box) => box[2])),
+                      Math.max(...planningBounds.map((box) => box[3])),
+                  ]
+                : turf.bbox(mapGeoData!);
+            const mask =
+                typeof Worker !== "undefined" &&
+                turf.coordAll(mapGeoData!).length > 10000
+                    ? await maskMap(mapGeoData!)
+                    : holedMask(mapGeoData!);
             mapGeoData = {
                 type: "FeatureCollection",
-                features: [holedMask(mapGeoData!)!],
+                features: [mask!],
             };
 
             map.eachLayer((layer: any) => {
@@ -215,8 +243,12 @@ export const Map = ({ className }: { className?: string }) => {
 
             questionFinishedMapData.set(mapGeoData);
 
-            if (autoZoom.get() && focus) {
-                const bbox = turf.bbox(holedMask(mapGeoData) as any);
+            if (
+                autoZoom.get() &&
+                focus &&
+                remainingBounds.every(Number.isFinite)
+            ) {
+                const bbox = remainingBounds;
                 const bounds = [
                     [bbox[1], bbox[0]],
                     [bbox[3], bbox[2]],
@@ -231,13 +263,24 @@ export const Map = ({ className }: { className?: string }) => {
         } catch (error) {
             console.log(error);
 
-            isLoading.set(false);
-            if (document.querySelectorAll(".Toastify__toast").length === 0) {
-                return toast.error("No solutions found / error occurred");
+            if (
+                document.querySelectorAll(".Toastify__toast--error").length ===
+                0
+            ) {
+                return toast.error(
+                    error instanceof Error
+                        ? error.message
+                        : "Could not calculate the map.",
+                );
             }
-        } finally {
-            isLoading.set(false);
         }
+    };
+
+    const refreshQuestions = (focus = false) => {
+        if (!map || isLoading.get()) return;
+        return withMapProgress(() => calculateQuestions(focus)).finally(() =>
+            isLoading.set(false),
+        );
     };
 
     const displayMap = useMemo(

--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -291,7 +291,7 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                 useCustomStations.set(geojson.useCustomStations);
             }
 
-            useLegacyDataSources.set(geojson.useLegacyDataSources === true);
+            useLegacyDataSources.set(geojson.useLegacyDataSources !== false);
 
             if (
                 geojson.customStations &&

--- a/src/components/OptionDrawers.tsx
+++ b/src/components/OptionDrawers.tsx
@@ -39,12 +39,14 @@ import {
     permanentOverlay,
     planningModeEnabled,
     polyGeoJSON,
+    questionModified,
     questions,
     save,
     showTutorial,
     thunderforestApiKey,
     triggerLocalRefresh,
     useCustomStations,
+    useLegacyDataSources,
 } from "@/lib/context";
 import {
     cn,
@@ -91,6 +93,7 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
     const $thunderforestApiKey = useStore(thunderforestApiKey);
     const $pastebinApiKey = useStore(pastebinApiKey);
     const $alwaysUsePastebin = useStore(alwaysUsePastebin);
+    const $useLegacyDataSources = useStore(useLegacyDataSources);
     const $followMe = useStore(followMe);
     const $customInitPref = useStore(customInitPreference);
     const $overpassHost = useStore(overpassHost);
@@ -287,6 +290,8 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
             if (typeof geojson.useCustomStations === "boolean") {
                 useCustomStations.set(geojson.useCustomStations);
             }
+
+            useLegacyDataSources.set(geojson.useLegacyDataSources === true);
 
             if (
                 geojson.customStations &&
@@ -685,6 +690,20 @@ export const OptionDrawers = ({ className }: { className?: string }) => {
                                         animateMapMovements.set(
                                             !$animateMapMovements,
                                         );
+                                    }}
+                                />
+                            </div>
+                            <div className="flex flex-row items-center gap-2">
+                                <label className="text-2xl font-semibold font-poppins">
+                                    Use original Overpass data?
+                                </label>
+                                <Checkbox
+                                    checked={$useLegacyDataSources}
+                                    onCheckedChange={() => {
+                                        useLegacyDataSources.set(
+                                            !$useLegacyDataSources,
+                                        );
+                                        questionModified();
                                     }}
                                 />
                             </div>

--- a/src/components/cards/matching.tsx
+++ b/src/components/cards/matching.tsx
@@ -367,6 +367,18 @@ export const MatchingQuestionComponent = ({
                     disabled={!data.drag || $isLoading}
                 />
             </SidebarMenuItem>
+            {data.type === "street-or-path" && (
+                <SidebarMenuItem className={MENU_ITEM_CLASSNAME}>
+                    <div className="flex flex-col items-center w-full">
+                        <span className="text-xs text-muted-foreground">
+                            Nearest street or path
+                        </span>
+                        <span className="text-sm font-semibold text-center">
+                            {data.street?.name || "Resolving nearest street…"}
+                        </span>
+                    </div>
+                </SidebarMenuItem>
+            )}
             {questionSpecific}
 
             {data.type !== "custom-zone" && (

--- a/src/components/cards/measuring.tsx
+++ b/src/components/cards/measuring.tsx
@@ -67,6 +67,18 @@ export const MeasuringQuestionComponent = ({
     let questionSpecific = <></>;
 
     switch (data.type) {
+        case "motorway":
+            if (data.motorway?.selection.mode === "major") {
+                questionSpecific = (
+                    <p className="px-2 text-sm">
+                        Using major motorways:{" "}
+                        {data.motorway.selection.names.join(", ")}. This
+                        selection is saved with the question. The map is
+                        approximate.
+                    </p>
+                );
+            }
+            break;
         case "admin-measure":
             questionSpecific = (
                 <>
@@ -362,10 +374,14 @@ export const MeasuringQuestionComponent = ({
                     disabled={!!$hiderMode || !data.drag || $isLoading}
                 >
                     <ToggleGroupItem value="further">
-                        Hider Further
+                        {data.type === "elevation"
+                            ? "Hider Lower"
+                            : "Hider Further"}
                     </ToggleGroupItem>
                     <ToggleGroupItem value="closer">
-                        Hider Closer
+                        {data.type === "elevation"
+                            ? "Hider Higher"
+                            : "Hider Closer"}
                     </ToggleGroupItem>
                 </ToggleGroup>
             </div>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -256,9 +256,20 @@ export const deleteCustomPreset = (id: string) => {
     customPresets.set(customPresets.get().filter((p) => p.id !== id));
 };
 
+export const showTutorial = persistentAtom<boolean>("showTutorials", true, {
+    encode: JSON.stringify,
+    decode: JSON.parse,
+});
+export const dataSourcePromptDismissed = persistentAtom<boolean>(
+    "dataSourcePromptDismissed",
+    false,
+    { encode: JSON.stringify, decode: JSON.parse },
+);
+if (showTutorial.get()) dataSourcePromptDismissed.set(true);
+
 export const useLegacyDataSources = persistentAtom<boolean>(
     "useLegacyDataSources",
-    false,
+    !showTutorial.get(),
     { encode: JSON.stringify, decode: JSON.parse },
 );
 
@@ -382,10 +393,6 @@ export const alwaysUsePastebin = persistentAtom<boolean>(
     },
 );
 
-export const showTutorial = persistentAtom<boolean>("showTutorials", true, {
-    encode: JSON.stringify,
-    decode: JSON.parse,
-});
 export const tutorialStep = atom<number>(0);
 
 export const customInitPreference = persistentAtom<"ask" | "blank" | "prefill">(

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -256,6 +256,12 @@ export const deleteCustomPreset = (id: string) => {
     customPresets.set(customPresets.get().filter((p) => p.id !== id));
 };
 
+export const useLegacyDataSources = persistentAtom<boolean>(
+    "useLegacyDataSources",
+    false,
+    { encode: JSON.stringify, decode: JSON.parse },
+);
+
 export const hidingZone = computed(
     [
         questions,
@@ -271,6 +277,7 @@ export const hidingZone = computed(
         includeDefaultStations,
         customPresets,
         permanentOverlay,
+        useLegacyDataSources,
     ],
     (
         q,
@@ -286,6 +293,7 @@ export const hidingZone = computed(
         includeDefault,
         presets,
         $permanentOverlay,
+        $useLegacyDataSources,
     ) => {
         if (geo !== null) {
             return {
@@ -300,6 +308,7 @@ export const hidingZone = computed(
                 includeDefaultStations: includeDefault,
                 presets: structuredClone(presets),
                 permanentOverlay: $permanentOverlay,
+                useLegacyDataSources: $useLegacyDataSources,
             };
         } else {
             const $loc = structuredClone(loc);
@@ -317,6 +326,7 @@ export const hidingZone = computed(
                 includeDefaultStations: includeDefault,
                 presets: structuredClone(presets),
                 permanentOverlay: $permanentOverlay,
+                useLegacyDataSources: $useLegacyDataSources,
             };
         }
     },

--- a/src/lib/mapProgress.ts
+++ b/src/lib/mapProgress.ts
@@ -1,0 +1,19 @@
+import { toast } from "react-toastify";
+
+let active = 0;
+
+export const withMapProgress = async <T>(
+    work: () => Promise<T>,
+): Promise<T> => {
+    const notice = toast.loading("Calculating the map...");
+    active++;
+    try {
+        return await work();
+    } finally {
+        active--;
+        toast.dismiss(notice);
+    }
+};
+
+export const showMapProgress = <T>(work: Promise<T>, message: string) =>
+    active ? work : toast.promise(work, { pending: message });

--- a/src/lib/memoizeAsync.ts
+++ b/src/lib/memoizeAsync.ts
@@ -1,0 +1,17 @@
+import _ from "lodash";
+
+// Share pending requests, but let failed requests retry.
+export const memoizeAsync = <A extends unknown[], R>(
+    fn: (...args: A) => Promise<R>,
+    key: (...args: A) => string,
+) => {
+    const cached = _.memoize((...args: A) => {
+        const id = key(...args);
+        const pending = fn(...args).catch((error) => {
+            if (cached.cache.get(id) === pending) cached.cache.delete(id);
+            throw error;
+        });
+        return pending;
+    }, key);
+    return cached;
+};

--- a/src/maps/api/cache.ts
+++ b/src/maps/api/cache.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
-import { toast } from "react-toastify";
+
+import { showMapProgress } from "@/lib/mapProgress";
 
 import { CacheType } from "./types";
 
@@ -26,6 +27,7 @@ export const cacheFetch = async (
     url: string,
     loadingText?: string,
     cacheType: CacheType = CacheType.CACHE,
+    signal?: AbortSignal,
 ) => {
     try {
         const cache = await determineCache(cacheType);
@@ -47,7 +49,7 @@ export const cacheFetch = async (
         }
 
         const fetchAndMaybeCache = async () => {
-            const response = await fetch(url);
+            const response = await fetch(url, { signal });
             if (response.ok) {
                 await cache.put(url, response.clone());
             } else {
@@ -61,9 +63,7 @@ export const cacheFetch = async (
 
         try {
             const response = await (loadingText
-                ? toast.promise(fetchPromise, {
-                      pending: loadingText,
-                  })
+                ? showMapProgress(fetchPromise, loadingText)
                 : fetchPromise);
 
             return response.clone();
@@ -71,9 +71,10 @@ export const cacheFetch = async (
             inFlightFetches.delete(inflightKey);
         }
     } catch (e) {
+        if (signal?.aborted) throw e;
         console.log(e); // Probably a caches not supported error
 
-        return fetch(url);
+        return fetch(url, { signal });
     }
 };
 

--- a/src/maps/api/constants.ts
+++ b/src/maps/api/constants.ts
@@ -10,6 +10,9 @@ export const OVERPASS_HOSTS = {
 } as const;
 
 export const GEOCODER_API = "https://photon.komoot.io/api/";
+// Override this URL to use another geodata server.
+export const JETLAG_GEODATA_API =
+    import.meta.env.PUBLIC_JETLAG_GEODATA_API ?? "https://jetlag-api.drori.dev";
 export const PASTEBIN_API_POST_URL =
     "https://cors-anywhere.com/https://pastebin.com/api/api_post.php";
 export const PASTEBIN_API_RAW_URL = "https://pastebin.com/raw/";

--- a/src/maps/api/index.ts
+++ b/src/maps/api/index.ts
@@ -3,5 +3,6 @@ export * from "./constants";
 export * from "./geo";
 export * from "./geocode";
 export * from "./importers";
+export * from "./jetlagGeodata";
 export * from "./overpass";
 export * from "./types";

--- a/src/maps/api/jetlagGeodata.ts
+++ b/src/maps/api/jetlagGeodata.ts
@@ -1,0 +1,180 @@
+import type {
+    BBox,
+    Feature,
+    FeatureCollection,
+    Geometry,
+    GeometryCollection,
+    MultiPolygon,
+    Polygon,
+} from "geojson";
+import { toast } from "react-toastify";
+
+import { cacheFetch } from "./cache";
+import { JETLAG_GEODATA_API } from "./constants";
+import { poiQueryBounds } from "./poiBounds";
+import { CacheType } from "./types";
+
+const request = async (
+    path: string,
+    params: Record<string, string | number>,
+) => {
+    const query = new URLSearchParams(
+        Object.entries({ ...params, v: "2" }).map(([key, value]) => [
+            key,
+            String(value),
+        ]),
+    );
+    const response = await cacheFetch(
+        `${JETLAG_GEODATA_API.replace(/\/$/, "")}/v1/${path}?${query}`,
+        "Loading map data...",
+        CacheType.CACHE,
+        AbortSignal.timeout(20000),
+    );
+    const body = await response.json();
+    if (!response.ok)
+        throw Object.assign(
+            new Error(body?.error?.message || `HTTP ${response.status}`),
+            { code: body?.error?.code },
+        );
+    return body;
+};
+
+const queryAt = (bbox: BBox, lat: number, lng: number) => ({
+    bbox: (bbox.length === 6
+        ? [bbox[0], bbox[1], bbox[3], bbox[4]]
+        : bbox
+    ).join(","),
+    lat,
+    lng,
+});
+
+export const fetchGeodataFeatures = async (
+    type: string,
+    bbox: BBox,
+    lat: number,
+    lng: number,
+    area?: FeatureCollection<Polygon | MultiPolygon>,
+): Promise<FeatureCollection<Exclude<Geometry, GeometryCollection>>> => {
+    const paths: Record<string, string> = {
+        "body-of-water": "water/features",
+        motorway: "motorways",
+        "highspeed-measure-shinkansen": "highspeed-rail",
+        peak: "peaks",
+    };
+    if (area && !paths[type]) {
+        const features = new Map<
+            string,
+            Feature<Exclude<Geometry, GeometryCollection>>
+        >();
+        const pending = poiQueryBounds(area).map((box) => ({ box, depth: 0 }));
+        let requests = 0;
+        while (pending.length) {
+            const { box, depth } = pending.shift()!;
+            if (++requests > 64)
+                throw Object.assign(
+                    new Error(
+                        "This area needs too many place queries. Narrow the play area and try again.",
+                    ),
+                    { code: "INCOMPLETE_COVERAGE" },
+                );
+            let result;
+            try {
+                result = await fetchGeodataFeatures(type, box, lat, lng);
+            } catch (error) {
+                if (
+                    (error as { code?: string }).code !==
+                        "INCOMPLETE_COVERAGE" ||
+                    depth >= 6
+                )
+                    throw error;
+                const axis = box[2] - box[0] >= box[3] - box[1] ? 0 : 1;
+                const middle = (box[axis] + box[axis + 2]) / 2;
+                const left = [...box] as BBox;
+                const right = [...box] as BBox;
+                left[axis + 2] = middle;
+                right[axis] = middle;
+                pending.unshift(
+                    { box: left, depth: depth + 1 },
+                    { box: right, depth: depth + 1 },
+                );
+                continue;
+            }
+            for (const feature of result.features) {
+                const key = String(
+                    feature.properties?.id ?? JSON.stringify(feature.geometry),
+                );
+                features.set(key, feature);
+            }
+        }
+        return { type: "FeatureCollection", features: [...features.values()] };
+    }
+    const result = await request(paths[type] || "places", {
+        ...queryAt(bbox, lat, lng),
+        type,
+        complete: 1,
+        ...(!paths[type] ? { limit: 20000 } : {}),
+    });
+    // Older servers can return a sample with a successful status.
+    if (
+        result.type !== "FeatureCollection" ||
+        result.complete !== true ||
+        !Array.isArray(result.features)
+    ) {
+        throw Object.assign(
+            new Error("Map data is incomplete for this area."),
+            { code: "INCOMPLETE_COVERAGE" },
+        );
+    }
+    return result;
+};
+
+export const tryFetchGeodataFeatures = async (
+    ...args: Parameters<typeof fetchGeodataFeatures>
+) => {
+    try {
+        return await fetchGeodataFeatures(...args);
+    } catch (error) {
+        if ((error as { code?: string }).code === "INCOMPLETE_COVERAGE")
+            throw error;
+        toast.info("The API is unavailable. Trying Overpass...");
+        return null;
+    }
+};
+
+export interface ElevationRegions {
+    higher: Feature<Polygon | MultiPolygon> | null;
+    lower: Feature<Polygon | MultiPolygon> | null;
+}
+
+export const fetchMotorways = (bbox: BBox) =>
+    request("motorways", { bbox: bbox.join(","), adaptive: 1, complete: 1 });
+
+export const fetchElevationRegions = async (
+    bbox: BBox,
+    lat: number,
+    lng: number,
+): Promise<ElevationRegions> => {
+    const result = await request("elevation/regions", queryAt(bbox, lat, lng));
+    if (!("higher" in result) || !("lower" in result)) {
+        throw new Error("Elevation data is unavailable for this area.");
+    }
+    return result;
+};
+
+export const fetchStreetRegion = async (
+    lat: number,
+    lng: number,
+    bbox: BBox,
+): Promise<{
+    streetName: string;
+    highway: string | null;
+    region: Feature<Polygon | MultiPolygon>;
+}> => request("street-or-path/region", queryAt(bbox, lat, lng));
+
+export const fetchLandmass = async (
+    lat: number,
+    lng: number,
+): Promise<Feature<Polygon | MultiPolygon>> => {
+    const result = await request("landmass", { lat, lng, snapMeters: 0 });
+    return result.landmass;
+};

--- a/src/maps/api/overpass.ts
+++ b/src/maps/api/overpass.ts
@@ -1,5 +1,5 @@
 import * as turf from "@turf/turf";
-import type { FeatureCollection, MultiPolygon } from "geojson";
+import type { FeatureCollection, MultiPolygon, Point } from "geojson";
 import _ from "lodash";
 import osmtogeojson from "osmtogeojson";
 import { toast } from "react-toastify";
@@ -10,11 +10,13 @@ import {
     overpassCustomHost,
     overpassHost,
     polyGeoJSON,
+    useLegacyDataSources,
 } from "@/lib/context";
 import { safeUnion } from "@/maps/geo-utils";
 
 import { cacheFetch, determineCache } from "./cache";
 import { LOCATION_FIRST_TAG, OVERPASS_HOSTS } from "./constants";
+import { tryFetchGeodataFeatures } from "./jetlagGeodata";
 import type {
     EncompassingTentacleQuestionSchema,
     HomeGameMatchingQuestions,
@@ -112,6 +114,34 @@ export const findTentacleLocations = async (
     question: TentacleLocationQuery,
     text: string = "Determining tentacle locations...",
 ) => {
+    if (!useLegacyDataSources.get()) {
+        const center = turf.point([question.lng, question.lat]);
+        // Over-fetch the bounding box, then apply the exact radius below.
+        const box = turf.bbox(
+            turf.circle(center, question.radius * 1.01, {
+                units: question.unit,
+            }),
+        );
+        const data = await tryFetchGeodataFeatures(
+            question.locationType,
+            box,
+            question.lat,
+            question.lng,
+        );
+        if (data)
+            return turf.featureCollection(
+                _.uniqBy(
+                    (data as FeatureCollection<Point>).features.filter(
+                        (point) =>
+                            turf.distance(center, point, {
+                                units: question.unit,
+                            }) <= question.radius,
+                    ),
+                    (point) => point.properties?.name,
+                ),
+            );
+    }
+
     const query = `
 [out:json][timeout:25];
 nwr["${LOCATION_FIRST_TAG[question.locationType]}"="${question.locationType}"](around:${turf.convertLength(

--- a/src/maps/api/poiBounds.ts
+++ b/src/maps/api/poiBounds.ts
@@ -1,0 +1,36 @@
+import { bbox, flatten } from "@turf/turf";
+import type { BBox, FeatureCollection, MultiPolygon, Polygon } from "geojson";
+
+export const poiQueryBounds = (
+    area: FeatureCollection<Polygon | MultiPolygon>,
+): BBox[] => {
+    const groups = new Map<string, number[]>();
+    for (const feature of flatten(area).features) {
+        const box = bbox(feature);
+        const midLng = (box[0] + box[2]) / 2;
+        const midLat = (box[1] + box[3]) / 2;
+        const key = `${Math.floor(midLng / 20)},${Math.floor(midLat / 20)}`;
+        const group = groups.get(key);
+        if (group) {
+            group[0] = Math.min(group[0], box[0]);
+            group[1] = Math.min(group[1], box[1]);
+            group[2] = Math.max(group[2], box[2]);
+            group[3] = Math.max(group[3], box[3]);
+        } else groups.set(key, [...box]);
+    }
+    const boxes = [...groups.values()];
+    // Keep distant islands separate; discard boxes already covered by another.
+    return boxes.filter(
+        (box, index) =>
+            !boxes.some(
+                (other, otherIndex) =>
+                    otherIndex !== index &&
+                    other[0] <= box[0] &&
+                    other[1] <= box[1] &&
+                    other[2] >= box[2] &&
+                    other[3] >= box[3] &&
+                    (otherIndex < index ||
+                        other.some((value, i) => value !== box[i])),
+            ),
+    ) as BBox[];
+};

--- a/src/maps/geo-utils/geometry.worker.ts
+++ b/src/maps/geo-utils/geometry.worker.ts
@@ -1,0 +1,44 @@
+import { booleanPointInPolygon, point, pointsWithinPolygon } from "@turf/turf";
+
+import { arcBufferToPoint, holedMask, modifyMapData } from "./operators";
+import { geoSpatialVoronoi } from "./voronoi";
+
+self.onmessage = async ({ data }) => {
+    try {
+        let region;
+        switch (data.operation) {
+            case "matching": {
+                const seeker = point([data.lng, data.lat]);
+                region = geoSpatialVoronoi(data.geometry).features.find(
+                    (cell) => booleanPointInPolygon(seeker, cell),
+                );
+                if (!region)
+                    throw new Error("Could not find the nearest-place region.");
+                break;
+            }
+            case "filter":
+                region = pointsWithinPolygon(data.geometry, data.area);
+                break;
+            case "mask":
+                region = holedMask(data.geometry);
+                break;
+            case "clip":
+                region = modifyMapData(data.geometry, data.region, data.within);
+                break;
+            case "buffer":
+                region = await arcBufferToPoint(
+                    data.geometry,
+                    data.lat,
+                    data.lng,
+                );
+                break;
+            default:
+                throw new Error("Unknown geometry operation.");
+        }
+        self.postMessage({ region });
+    } catch (error) {
+        self.postMessage({
+            error: error instanceof Error ? error.message : String(error),
+        });
+    }
+};

--- a/src/maps/geo-utils/geometryWorker.ts
+++ b/src/maps/geo-utils/geometryWorker.ts
@@ -1,0 +1,104 @@
+import { pointsWithinPolygon } from "@turf/turf";
+import type {
+    Feature,
+    FeatureCollection,
+    MultiPolygon,
+    Point,
+    Polygon,
+} from "geojson";
+
+import { showMapProgress } from "@/lib/mapProgress";
+
+const runGeometry = <T>(data: Record<string, unknown>): Promise<T> =>
+    showMapProgress(
+        new Promise<T>((resolve, reject) => {
+            const worker = new Worker(
+                new URL("./geometry.worker.ts", import.meta.url),
+                { type: "module" },
+            );
+            const timeout = setTimeout(() => {
+                worker.terminate();
+                reject(
+                    new Error(
+                        "This area took too long to calculate. Try a smaller area.",
+                    ),
+                );
+            }, 60000);
+            const finish = () => {
+                clearTimeout(timeout);
+                worker.terminate();
+            };
+            worker.onmessage = ({ data }) => {
+                finish();
+                if ("error" in data) reject(new Error(data.error));
+                else resolve(data.region);
+            };
+            worker.onerror = (event) => {
+                finish();
+                reject(
+                    new Error(event.message || "Could not calculate the map."),
+                );
+            };
+            try {
+                worker.postMessage(data);
+            } catch (error) {
+                finish();
+                reject(error);
+            }
+        }),
+        "Calculating the map...",
+    );
+
+export const bufferPois = (
+    geometry: FeatureCollection,
+    lat: number,
+    lng: number,
+) =>
+    runGeometry<Feature<MultiPolygon>>({
+        operation: "buffer",
+        geometry,
+        lat,
+        lng,
+    });
+
+export const clipMap = (
+    geometry: FeatureCollection,
+    region: Feature<Polygon | MultiPolygon>,
+    within: boolean,
+) =>
+    runGeometry<Feature<Polygon | MultiPolygon> | null>({
+        operation: "clip",
+        geometry,
+        region,
+        within,
+    });
+
+export const maskMap = (geometry: FeatureCollection | Feature) =>
+    runGeometry<Feature<Polygon | MultiPolygon>>({
+        operation: "mask",
+        geometry,
+    });
+
+export const filterPois = async (
+    geometry: FeatureCollection<Point>,
+    area: FeatureCollection<Polygon | MultiPolygon>,
+) =>
+    typeof Worker !== "undefined" && geometry.features.length > 1000
+        ? runGeometry<FeatureCollection<Point>>({
+              operation: "filter",
+              geometry,
+              area,
+          })
+        : pointsWithinPolygon(geometry, area);
+
+export const matchingRegion = (
+    geometry: FeatureCollection<Point>,
+    lat: number,
+    lng: number,
+) =>
+    runGeometry<Feature<Polygon | MultiPolygon>>({
+        operation: "matching",
+        geometry,
+        lat,
+        lng,
+    });

--- a/src/maps/geo-utils/operators.ts
+++ b/src/maps/geo-utils/operators.ts
@@ -14,7 +14,7 @@ import type {
     Polygon,
 } from "geojson";
 
-import { BLANK_GEOJSON } from "@/maps/api";
+import { BLANK_GEOJSON } from "@/maps/api/constants";
 
 export { geoSpatialVoronoi } from "@/maps/geo-utils/voronoi";
 
@@ -30,6 +30,9 @@ export const holedMask = (
         | Feature<Polygon | MultiPolygon>
         | FeatureCollection<Polygon | MultiPolygon>,
 ) => {
+    if ("features" in input && input.features.length === 0)
+        return BLANK_GEOJSON.features[0] as Feature<Polygon>;
+
     return turf.difference(
         turf.featureCollection([
             BLANK_GEOJSON.features[0] as Feature<Polygon>,

--- a/src/maps/index.ts
+++ b/src/maps/index.ts
@@ -9,6 +9,7 @@ import {
     adjustPerMeasuring,
     hiderifyMeasuring,
     measuringPlanningPolygon,
+    prepareMotorwayQuestion,
 } from "./questions/measuring";
 import {
     adjustPerRadius,
@@ -81,29 +82,25 @@ export async function adjustMapGeoDataForQuestion(
         return mapGeoData;
     }
 
-    try {
-        switch (question?.id) {
-            case "radius":
-                return await adjustPerRadius(question.data, mapGeoData);
-            case "thermometer":
-                return await adjustPerThermometer(question.data, mapGeoData);
-            case "tentacles":
-                if (question.data.location === false) {
-                    return adjustPerRadius(
-                        { ...question.data, within: false },
-                        mapGeoData,
-                    );
-                }
-                return await adjustPerTentacle(question.data, mapGeoData);
-            case "matching":
-                return await adjustPerMatching(question.data, mapGeoData);
-            case "measuring":
-                return await adjustPerMeasuring(question.data, mapGeoData);
-            default:
-                return mapGeoData;
-        }
-    } catch {
-        return mapGeoData;
+    switch (question?.id) {
+        case "radius":
+            return await adjustPerRadius(question.data, mapGeoData);
+        case "thermometer":
+            return await adjustPerThermometer(question.data, mapGeoData);
+        case "tentacles":
+            if (question.data.location === false) {
+                return adjustPerRadius(
+                    { ...question.data, within: false },
+                    mapGeoData,
+                );
+            }
+            return await adjustPerTentacle(question.data, mapGeoData);
+        case "matching":
+            return await adjustPerMatching(question.data, mapGeoData);
+        case "measuring":
+            return await adjustPerMeasuring(question.data, mapGeoData);
+        default:
+            return mapGeoData;
     }
 }
 
@@ -117,6 +114,18 @@ export async function applyQuestionsToMapGeoData(
     ) => void,
 ): Promise<any> {
     for (const question of questions) {
+        if (
+            question.id === "measuring" &&
+            question.data.type === "motorway" &&
+            !question.data.hidden
+        ) {
+            question.data = await prepareMotorwayQuestion(
+                question.data,
+                mapGeoData,
+                question.key,
+            );
+            await hiderifyMeasuring(question.data);
+        }
         if (planningModeCallback) {
             const planningPolygon = await determinePlanningPolygon(
                 question,
@@ -131,6 +140,8 @@ export async function applyQuestionsToMapGeoData(
         }
 
         mapGeoData = await adjustMapGeoDataForQuestion(question, mapGeoData);
+
+        if (!mapGeoData) return { type: "FeatureCollection", features: [] };
 
         if (mapGeoData.type !== "FeatureCollection") {
             mapGeoData = {

--- a/src/maps/questions/matching.ts
+++ b/src/maps/questions/matching.ts
@@ -15,17 +15,28 @@ import {
     mapGeoJSON,
     mapGeoLocation,
     polyGeoJSON,
+    questionModified,
+    useLegacyDataSources,
 } from "@/lib/context";
+import { memoizeAsync } from "@/lib/memoizeAsync";
 import {
+    fetchLandmass,
+    fetchStreetRegion,
     findAdminBoundary,
     findPlacesInZone,
     LOCATION_FIRST_TAG,
     nearestToQuestion,
     prettifyLocation,
     trainLineNodeFinder,
+    tryFetchGeodataFeatures,
 } from "@/maps/api";
 import { holedMask, modifyMapData, safeUnion } from "@/maps/geo-utils";
 import { geoSpatialVoronoi } from "@/maps/geo-utils";
+import {
+    clipMap,
+    filterPois,
+    matchingRegion,
+} from "@/maps/geo-utils/geometryWorker";
 import type {
     APILocations,
     HomeGameMatchingQuestions,
@@ -79,6 +90,28 @@ export const findMatchingPlaces = async (question: MatchingQuestion) => {
         case "park-full": {
             const location = question.type.split("-full")[0] as APILocations;
 
+            const area = mapGeoJSON.get();
+            if (!useLegacyDataSources.get() && area) {
+                const prepared = await tryFetchGeodataFeatures(
+                    location,
+                    turf.bbox(area),
+                    question.lat,
+                    question.lng,
+                    area,
+                );
+                if (prepared) {
+                    const points = await filterPois(
+                        prepared as FeatureCollection<Point>,
+                        area,
+                    );
+                    if (!points.features.length)
+                        throw new Error(
+                            `No ${prettifyLocation(location, true).toLowerCase()} found in this area.`,
+                        );
+                    return points.features;
+                }
+            }
+
             const data = await findPlacesInZone(
                 `[${LOCATION_FIRST_TAG[location]}=${location}]`,
                 `Finding ${prettifyLocation(location, true).toLowerCase()}...`,
@@ -118,7 +151,7 @@ export const findMatchingPlaces = async (question: MatchingQuestion) => {
     }
 };
 
-export const determineMatchingBoundary = _.memoize(
+const matchingBoundary = memoizeAsync(
     async (question: MatchingQuestion) => {
         let boundary;
 
@@ -141,6 +174,10 @@ export const determineMatchingBoundary = _.memoize(
             }
             case "custom-zone": {
                 boundary = question.geo;
+                break;
+            }
+            case "landmass": {
+                boundary = await fetchLandmass(question.lat, question.lng);
                 break;
             }
             case "zone": {
@@ -229,6 +266,15 @@ export const determineMatchingBoundary = _.memoize(
             case "custom-points": {
                 const data = await findMatchingPlaces(question);
 
+                if (!data?.length)
+                    throw new Error("No places found in this area.");
+                if (typeof Worker !== "undefined" && data.length > 1000)
+                    return matchingRegion(
+                        turf.featureCollection(data),
+                        question.lat,
+                        question.lng,
+                    );
+
                 const voronoi = geoSpatialVoronoi(data);
                 const point = turf.point([question.lng, question.lat]);
 
@@ -251,11 +297,32 @@ export const determineMatchingBoundary = _.memoize(
             lng: question.lng,
             cat: question.cat,
             geo: question.geo,
+            legacy: useLegacyDataSources.get(),
             entirety: polyGeoJSON.get()
                 ? polyGeoJSON.get()
                 : mapGeoLocation.get(),
         }),
 );
+
+export const determineMatchingBoundary = async (question: MatchingQuestion) => {
+    if (question.type !== "street-or-path") return matchingBoundary(question);
+    const street = await fetchStreetRegion(
+        question.lat,
+        question.lng,
+        turf.bbox(mapGeoJSON.get()!),
+    );
+    if (
+        question.street?.name !== street.streetName ||
+        question.street?.highway !== street.highway
+    ) {
+        question.street = {
+            name: street.streetName,
+            highway: street.highway,
+        };
+        questionModified();
+    }
+    return street.region;
+};
 
 export const adjustPerMatching = async (
     question: MatchingQuestion,
@@ -268,6 +335,9 @@ export const adjustPerMatching = async (
     if (boundary === false) {
         return mapData;
     }
+
+    if (typeof Worker !== "undefined" && turf.coordAll(mapData).length > 10000)
+        return clipMap(mapData, boundary, question.same);
 
     return modifyMapData(mapData, boundary, question.same);
 };
@@ -416,15 +486,11 @@ export const hiderifyMatching = async (question: MatchingQuestion) => {
 };
 
 export const matchingPlanningPolygon = async (question: MatchingQuestion) => {
-    try {
-        const boundary = await determineMatchingBoundary(question);
+    const boundary = await determineMatchingBoundary(question);
 
-        if (boundary === false) {
-            return false;
-        }
-
-        return turf.polygonToLine(boundary);
-    } catch {
+    if (boundary === false) {
         return false;
     }
+
+    return turf.polygonToLine(boundary);
 };

--- a/src/maps/questions/measuring.ts
+++ b/src/maps/questions/measuring.ts
@@ -1,5 +1,5 @@
 import * as turf from "@turf/turf";
-import type { Feature, MultiPolygon } from "geojson";
+import type { Feature, FeatureCollection, MultiPolygon, Point } from "geojson";
 import _ from "lodash";
 import osmtogeojson from "osmtogeojson";
 import { toast } from "react-toastify";
@@ -9,10 +9,17 @@ import {
     mapGeoJSON,
     mapGeoLocation,
     polyGeoJSON,
+    questionModified,
+    questions,
     trainStations,
+    useLegacyDataSources,
 } from "@/lib/context";
+import { memoizeAsync } from "@/lib/memoizeAsync";
 import {
     fetchCoastline,
+    fetchElevationRegions,
+    fetchGeodataFeatures,
+    fetchMotorways,
     findAdminBoundary,
     findPlacesInZone,
     findPlacesSpecificInZone,
@@ -20,6 +27,7 @@ import {
     nearestToQuestion,
     prettifyLocation,
     QuestionSpecificLocation,
+    tryFetchGeodataFeatures,
 } from "@/maps/api";
 import {
     arcBufferToPoint,
@@ -29,11 +37,45 @@ import {
     holedMask,
     modifyMapData,
 } from "@/maps/geo-utils";
+import {
+    bufferPois,
+    clipMap,
+    filterPois,
+} from "@/maps/geo-utils/geometryWorker";
 import type {
     APILocations,
     HomeGameMeasuringQuestions,
     MeasuringQuestion,
 } from "@/maps/schema";
+import { motorwaySnapshotSchema } from "@/maps/schema";
+
+export const prepareMotorwayQuestion = async (
+    question: MeasuringQuestion,
+    remainingArea: FeatureCollection,
+    questionKey?: number,
+) => {
+    if (question.type !== "motorway" || question.motorway) return question;
+    const bbox = turf.bbox(remainingArea);
+    const data = await fetchMotorways(bbox);
+    if (data.complete !== true || !data.features?.length)
+        throw new Error("No motorway selection is available for this area.");
+    const current =
+        questionKey === undefined
+            ? undefined
+            : questions
+                  .get()
+                  .find(
+                      (entry) =>
+                          entry.key === questionKey && entry.id === "measuring",
+                  );
+    const currentData = current?.id === "measuring" ? current.data : question;
+    question.motorway =
+        currentData.motorway ?? motorwaySnapshotSchema.parse({ ...data, bbox });
+    currentData.motorway = question.motorway;
+    // Save the roads themselves so dataset updates cannot change an answer.
+    questionModified();
+    return currentData;
+};
 
 export interface AdminZoneInfo {
     name: string;
@@ -119,6 +161,16 @@ export const determineMeasuringBoundary = async (
 
     switch (question.type) {
         case "highspeed-measure-shinkansen": {
+            if (!useLegacyDataSources.get()) {
+                const rail = await tryFetchGeodataFeatures(
+                    question.type,
+                    bBox,
+                    question.lat,
+                    question.lng,
+                );
+                if (rail?.features.length) return rail.features;
+            }
+
             const features = osmtogeojson(
                 await findPlacesInZone(
                     "[highspeed=yes]",
@@ -152,6 +204,21 @@ export const determineMeasuringBoundary = async (
             // Convert the polygon to its outline (the border)
             const outline = turf.polygonToLine(zoneInfo.boundary);
             return [outline];
+        }
+        case "motorway": {
+            await prepareMotorwayQuestion(question, mapGeoJSON.get()!);
+            return question.motorway!.features;
+        }
+        case "body-of-water": {
+            const data = await fetchGeodataFeatures(
+                question.type,
+                bBox,
+                question.lat,
+                question.lng,
+            );
+            if (!data.features.length)
+                throw new Error("No matching features found in this area.");
+            return data.features;
         }
         case "coastline": {
             const coastline = turf.lineToPolygon(
@@ -243,6 +310,27 @@ export const determineMeasuringBoundary = async (
         case "park-full": {
             const location = question.type.split("-full")[0] as APILocations;
 
+            if (!useLegacyDataSources.get()) {
+                const prepared = await tryFetchGeodataFeatures(
+                    location,
+                    bBox,
+                    question.lat,
+                    question.lng,
+                    mapGeoJSON.get()!,
+                );
+                if (prepared) {
+                    const points = await filterPois(
+                        prepared as FeatureCollection<Point>,
+                        mapGeoJSON.get()!,
+                    );
+                    if (!points.features.length)
+                        throw new Error(
+                            `No ${prettifyLocation(location, true).toLowerCase()} found in this area.`,
+                        );
+                    return turf.combine(points).features;
+                }
+            }
+
             const data = await findPlacesInZone(
                 `[${LOCATION_FIRST_TAG[location]}=${location}]`,
                 `Finding ${prettifyLocation(location, true).toLowerCase()}...`,
@@ -307,12 +395,49 @@ export const determineMeasuringBoundary = async (
     }
 };
 
-const bufferedDeterminer = _.memoize(
+const bufferedDeterminer = memoizeAsync(
     async (question: MeasuringQuestion) => {
         const placeData = await determineMeasuringBoundary(question);
 
         if (placeData === false || placeData === undefined) return false;
 
+        if (question.type === "motorway" && question.motorway) {
+            const point = turf.point([question.lng, question.lat]);
+            const lines = question.motorway.features.flatMap(
+                (feature) => feature.geometry.coordinates,
+            );
+            const distance = Math.min(
+                ...lines.map((line) =>
+                    turf.pointToLineDistance(point, turf.lineString(line), {
+                        units: "kilometers",
+                    }),
+                ),
+            );
+            // Buffer the joined roads without the slow ArcGIS calculation.
+            if (distance === 0) return turf.multiPolygon([]);
+            const region = turf.buffer(turf.multiLineString(lines), distance, {
+                units: "kilometers",
+            });
+            if (!region)
+                throw new Error("Could not calculate the motorway boundary.");
+            return region;
+        }
+
+        if (
+            typeof Worker !== "undefined" &&
+            placeData.some(
+                (feature) =>
+                    "geometry" in feature &&
+                    feature.geometry.type === "MultiPoint" &&
+                    feature.geometry.coordinates.length > 1000,
+            )
+        ) {
+            return bufferPois(
+                turf.featureCollection(placeData as any),
+                question.lat,
+                question.lng,
+            );
+        }
         return arcBufferToPoint(
             turf.featureCollection(placeData as any),
             question.lat,
@@ -329,7 +454,24 @@ const bufferedDeterminer = _.memoize(
                 : mapGeoLocation.get(),
             geo: (question as any).geo,
             cat: (question as any).cat,
+            legacy: useLegacyDataSources.get(),
+            motorway: question.motorway,
         }),
+);
+
+const elevationRegion = memoizeAsync(
+    (question: MeasuringQuestion) =>
+        fetchElevationRegions(
+            turf.bbox(mapGeoJSON.get()!),
+            question.lat,
+            question.lng,
+        ),
+    (question) =>
+        JSON.stringify([
+            question.lat,
+            question.lng,
+            turf.bbox(mapGeoJSON.get()!),
+        ]),
 );
 
 export const adjustPerMeasuring = async (
@@ -338,16 +480,51 @@ export const adjustPerMeasuring = async (
 ) => {
     if (mapData === null) return;
 
+    if (question.type === "elevation") {
+        const regions = await elevationRegion(question);
+        const region = question.hiderCloser ? regions.higher : regions.lower;
+        return region ? modifyMapData(mapData, region, true) : null;
+    }
+
     const buffer = await bufferedDeterminer(question);
 
     if (buffer === false) return mapData;
 
+    if (typeof Worker !== "undefined" && turf.coordAll(buffer).length > 10000) {
+        return clipMap(mapData, buffer, question.hiderCloser);
+    }
     return modifyMapData(mapData, buffer, question.hiderCloser);
 };
 
 export const hiderifyMeasuring = async (question: MeasuringQuestion) => {
     const $hiderMode = hiderMode.get();
     if ($hiderMode === false) {
+        return question;
+    }
+
+    if (question.type === "motorway") {
+        const region = await bufferedDeterminer(question);
+        if (!region)
+            throw new Error("Could not calculate the motorway answer.");
+        const hiderCloser = turf.booleanPointInPolygon(
+            turf.point([$hiderMode.longitude, $hiderMode.latitude]),
+            region,
+        );
+        if (question.hiderCloser !== hiderCloser) {
+            question.hiderCloser = hiderCloser;
+            questionModified();
+        }
+        return question;
+    }
+
+    if (question.type === "elevation") {
+        const { higher, lower } = await elevationRegion(question);
+        const hider = turf.point([$hiderMode.longitude, $hiderMode.latitude]);
+        const isHigher = !!higher && turf.booleanPointInPolygon(hider, higher);
+        if (!isHigher && !(lower && turf.booleanPointInPolygon(hider, lower))) {
+            throw new Error("No elevation data at the hiding location.");
+        }
+        question.hiderCloser = isHigher;
         return question;
     }
 
@@ -465,13 +642,12 @@ export const hiderifyMeasuring = async (question: MeasuringQuestion) => {
 };
 
 export const measuringPlanningPolygon = async (question: MeasuringQuestion) => {
-    try {
-        const buffered = await bufferedDeterminer(question);
+    const buffered =
+        question.type === "elevation"
+            ? (await elevationRegion(question)).higher
+            : await bufferedDeterminer(question);
 
-        if (buffered === false) return false;
+    if (!buffered) return false;
 
-        return turf.polygonToLine(buffered);
-    } catch {
-        return false;
-    }
+    return turf.polygonToLine(buffered);
 };

--- a/src/maps/schema.ts
+++ b/src/maps/schema.ts
@@ -206,11 +206,21 @@ const baseMatchingQuestionSchema = ordinaryBaseQuestionSchema.extend({
 });
 
 const ordinaryMatchingQuestionSchema = baseMatchingQuestionSchema.extend({
+    street: z
+        .object({
+            name: z.string(),
+            highway: z.string().nullable(),
+        })
+        .optional(),
     type: z
         .union([
             z
                 .literal("airport")
                 .describe("Commercial Airport In Zone Question"),
+            z.literal("landmass").describe("Same Landmass Question"),
+            z
+                .literal("street-or-path")
+                .describe("Same Nearest Street or Path Question"),
             z
                 .literal("major-city")
                 .describe("Major City (1,000,000+ people) In Zone Question"),
@@ -319,14 +329,44 @@ export const matchingQuestionSchema = z.union([
     homeGameMatchingQuestionsSchema.describe("Hiding Zone Mode"),
 ]);
 
+export const motorwaySnapshotSchema = z.object({
+    bbox: z.tuple([z.number(), z.number(), z.number(), z.number()]),
+    selection: z.object({
+        mode: z.enum(["all", "major"]),
+        names: z.array(z.string()),
+    }),
+    features: z
+        .array(
+            z.object({
+                type: z.literal("Feature"),
+                properties: z.record(z.unknown()).nullable(),
+                geometry: z.object({
+                    type: z.literal("MultiLineString"),
+                    coordinates: z
+                        .array(
+                            z.array(z.tuple([z.number(), z.number()])).min(2),
+                        )
+                        .min(1),
+                }),
+            }),
+        )
+        .min(1),
+});
+
 const baseMeasuringQuestionSchema = ordinaryBaseQuestionSchema.extend({
     hiderCloser: z.boolean().default(true),
+    motorway: motorwaySnapshotSchema.optional(),
 });
 
 const ordinaryMeasuringQuestionSchema = baseMeasuringQuestionSchema.extend({
     type: z
         .union([
             z.literal("coastline").describe("Coastline Question"),
+            z.literal("body-of-water").describe("Body of Water Question"),
+            z.literal("motorway").describe("Motorway Question"),
+            z
+                .literal("elevation")
+                .describe("Elevation (Higher/Lower) Question"),
             z
                 .literal("airport")
                 .describe("Commercial Airport In Zone Question"),

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,6 +13,7 @@ import {
 import { QuestionSidebar } from "@/components/QuestionSidebar";
 import { ZoneSidebar } from "@/components/ZoneSidebar";
 import { OptionDrawers } from "@/components/OptionDrawers";
+import { DataSourceDialog } from "@/components/DataSourceDialog";
 import { TutorialDialog } from "@/components/TutorialDialog";
 ---
 
@@ -59,6 +60,7 @@ import { TutorialDialog } from "@/components/TutorialDialog";
             </main>
             <ZoneSidebar client:only />
             <TutorialDialog client:only />
+            <DataSourceDialog client:only />
         </SidebarProviderR>
     </SidebarProviderL>
 </Layout>

--- a/tests/geodataApi.test.ts
+++ b/tests/geodataApi.test.ts
@@ -1,0 +1,18 @@
+import { expect, test, vi } from "vitest";
+
+const cacheFetch = vi.hoisted(() => vi.fn());
+vi.mock("@/maps/api/cache", () => ({ cacheFetch }));
+import { fetchGeodataFeatures } from "@/maps/api/jetlagGeodata";
+
+test("partial POI data cannot become a committed answer", async () => {
+    cacheFetch.mockResolvedValue(
+        Response.json({
+            type: "FeatureCollection",
+            features: [],
+            complete: false,
+        }),
+    );
+    await expect(
+        fetchGeodataFeatures("museum", [0, 0, 1, 1], 0, 0),
+    ).rejects.toThrow("incomplete");
+});


### PR DESCRIPTION
This uses an API I set up for POI lookups as well as HSR data, and also adds five question types that were pending. Elevation, nearest body of water, landmass, motorways, and nearest street or path are all added here. API is used for data and the browser still does all the compute, I made some changes to allow it to also handle more intensive questions (like all museums across the US).

Larger place queroes get split into smaller regions and incomplete results get rejects, geometry also runs in a background worker that has a loading notice when needed. Motorway questions, should default to only major roads when the remaining area is large (though thismight need improvement). The original overpass source is still available via the "Use original Overpass data?" button in Options, and if the api goes down, the questions that have overpass equivalents that rely on it should fall back to overpass. 

Lint, build, and all tests pass, I also added a new test for incomplete data and checked all five new question types and a museum question in the browser.

Full-US museum calculations can still take 35–41 seconds. 

Airports still use overpass, as my definition of what an airport is differs from what the APP uses, the api follows the IATA international airport list, so the overpass query returns more airports than what the API would, swapping to the IATA definition of airports would also probably be better done by uploading a JSON file containing all of them to the repo.

